### PR TITLE
🔀 next-redux-wrapper 8.0.0 업데이트

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,17 @@ import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import InitMocks from '@/mocks'
 import wrapper from '@/store'
+import { Provider } from 'react-redux'
 
 InitMocks()
 
-function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+function App({ Component, ...rest }: AppProps) {
+  const { store, props } = wrapper.useWrappedStore(rest)
+  return (
+    <Provider store={store}>
+      <Component {...props} />
+    </Provider>
+  )
 }
 
-export default wrapper.withRedux(App)
+export default App


### PR DESCRIPTION
## 💡 개요

next-redux-wrapper 라이브러리의 업데이트로 인해 사용법이 살짝 달라졌어요

## 📃 작업내용

[참고 자료](https://velog.io/@mangojang/error-next-redux-wrapper-%EC%82%AC%EC%9A%A9-%EC%8B%9C-Use-createWrapper)