### PR TITLE
🔀 useFetch hook의 타입 수정

### DIFF
--- a/hooks/useFetch.tsx
+++ b/hooks/useFetch.tsx
@@ -14,7 +14,7 @@ const useFetch = <T,>({ url, method, onSuccess, onFailure }: Props<T>) => {
   const [data, setData] = useState<T | null>(null)
 
   const fetch = useCallback(
-    async (body?: T) => {
+    async (body?: any) => {
       setIsLoading(true)
 
       try {


### PR DESCRIPTION
## 💡 개요

useFetch의 request body type을 잘못 작성해 수정을 했습니다

## 📃 작업내용

- 반환하는 fetch함수의 request body type을 `any`로 변경했습니다

> request body의 경우 항상 다른 타입의 값이 들오기 때문에 `any`로 하는 게 좋습니다 (참고로 axios도 any로 설정했음)
