### PR TITLE
🔀 portal에 모달 닫기 기능 추가

### DIFF
--- a/components/ClubCreationModal/index.tsx
+++ b/components/ClubCreationModal/index.tsx
@@ -20,7 +20,7 @@ const ClubCreationModal = ({ onClose }: Props) => {
   }))
 
   return (
-    <Portal>
+    <Portal onClose={onClose}>
       <S.Wrapper>
         <S.TopContent>
           <S.CloseButton onClick={onClose}>

--- a/components/Portal/index.tsx
+++ b/components/Portal/index.tsx
@@ -1,12 +1,19 @@
-import { ReactNode, useEffect, useState } from 'react'
+import {
+  cloneElement,
+  useEffect,
+  useState,
+  MouseEvent,
+  ReactElement,
+} from 'react'
 import ReactDOM from 'react-dom'
 import * as S from './style'
 
 interface Props {
-  children: ReactNode
+  children: ReactElement
+  onClose?: () => void
 }
 
-const Portal = ({ children }: Props) => {
+const Portal = ({ children, onClose }: Props) => {
   const [isCSR, setIsCSR] = useState(false)
 
   useEffect(() => {
@@ -19,7 +26,16 @@ const Portal = ({ children }: Props) => {
   const portal = document.getElementById('modal')
   if (!portal) throw new Error('Not found modal')
 
-  return ReactDOM.createPortal(<S.Wrapper>{children}</S.Wrapper>, portal)
+  const onClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+  }
+
+  return ReactDOM.createPortal(
+    <S.Wrapper onClick={onClose}>
+      {cloneElement(children, { onClick })}
+    </S.Wrapper>,
+    portal
+  )
 }
 
 export default Portal


### PR DESCRIPTION
## 💡 개요

모달 바깥을 눌렀을 때 onClose 함수가 실행되도록 만들었습니다

## 📃 작업내용

- onClose 값을 props로 받아서 Portal의 최상위 element의 onClick에 넣어줬습니다
- 이벤트 버블링 문제가 발생해 children의 onClick에 이벤트 버블링을 막는 함수를 넣어줬습니다
- ClubCreationModal 컴포넌트에서 Portal 컴포넌트로 onClose 함수를 넘겨주게 했습니다

## 🍴 사용방법

<img width="229" alt="스크린샷 2023-02-13 오후 2 28 46" src="https://user-images.githubusercontent.com/57276315/218378088-d9a0ee2c-fa0b-475e-8421-0235dd981478.png">

portal을 사용하면서 onClose를 props로 넘겨주면 됩니다
참고로 onClose 값은 필수 값이 아닙니다