### PR TITLE
🔀 500 에러 기본 메시지 추가

### DIFF
--- a/hooks/useFetch.tsx
+++ b/hooks/useFetch.tsx
@@ -52,7 +52,7 @@ const useFetch = <T,>({
           toast.error(errors[e.response.status], toastOption)
 
         if (isAxiosError(e) && e.response && e.response.status === 500)
-          toast.error('알 수 없는 에러가 발생했습니다')
+          toast.error('알 수 없는 에러가 발생했습니다', toastOption)
 
         if (onFailure) await onFailure(e)
       } finally {

--- a/hooks/useFetch.tsx
+++ b/hooks/useFetch.tsx
@@ -51,6 +51,9 @@ const useFetch = <T,>({
         )
           toast.error(errors[e.response.status], toastOption)
 
+        if (isAxiosError(e) && e.response && e.response.status === 500)
+          toast.error('알 수 없는 에러가 발생했습니다')
+
         if (onFailure) await onFailure(e)
       } finally {
         setIsLoading(false)

--- a/mocks/handlers/api/user/get.ts
+++ b/mocks/handlers/api/user/get.ts
@@ -2,7 +2,6 @@ import { rest } from 'msw'
 import serverApi from '../../serverApi'
 
 const getUser = rest.get(serverApi('/user'), (_req, res, ctx) => {
-  return res(ctx.status(500))
   return res(
     ctx.status(200),
     ctx.json({

--- a/mocks/handlers/api/user/get.ts
+++ b/mocks/handlers/api/user/get.ts
@@ -2,6 +2,7 @@ import { rest } from 'msw'
 import serverApi from '../../serverApi'
 
 const getUser = rest.get(serverApi('/user'), (_req, res, ctx) => {
+  return res(ctx.status(500))
   return res(
     ctx.status(200),
     ctx.json({


### PR DESCRIPTION
## 💡 개요

500에러는 모든 api 요청에 필요할 것 같아 기본 메시지를 추가했습니다

## 📃 작업내용

형우의 요청대로 아래 메시지 처럼 하고 싶었지만

```
알 수 없는 에러 발생했습니다?
지속될시
문의주세요
```

react-toastify가 엔터를 인식하지 못해 아래와 같이 간단하게 변경했습니다

```
알 수 없는 에러 발생했습니다
```

## 🙋‍♂️ 질문사항

더 좋은 500 에러 메시지가 있다면 알려주세요