### PR TITLE
React Portal 스크롤 기능 막기

### DIFF
--- a/components/Portal/index.tsx
+++ b/components/Portal/index.tsx
@@ -20,6 +20,18 @@ const Portal = ({ children, onClose }: Props) => {
     setIsCSR(true)
   }, [])
 
+  useEffect(() => {
+    document.body.style.cssText = `
+      position: fixed; 
+      top: -${window.scrollY}px;
+      width: 100%;`
+    return () => {
+      const scrollY = document.body.style.top
+      document.body.style.cssText = ''
+      window.scrollTo(0, -parseInt(scrollY))
+    }
+  }, [])
+
   if (typeof window === 'undefined') return <></>
   if (!isCSR) return <></>
 

--- a/components/Portal/style.ts
+++ b/components/Portal/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 
 export const Wrapper = styled.div`
-  position: absolute;
+  position: fixed;
   z-index: 1000;
   top: 0;
   left: 0;


### PR DESCRIPTION
## 💡 개요

아무 생각 없이 만들었더니 스크롤 하는 기능 때문에 이상하게 보이는 문제가 생김

## 📃 작업내용

- portal의 최 상위 div에 fixed 속성 추가
- useEffect에서 body에 fixed를 주는 작업을 만듬