### PR TITLE
🔀 next-redux-wrapper 설정 코드 레거시 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@reduxjs/toolkit": "^1.9.2",
     "axios": "^1.2.6",
     "next": "13.1.6",
-    "next-redux-wrapper": "^8.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,16 +4,20 @@ import InitMocks from '@/mocks'
 import wrapper from '@/store'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
+import { Provider } from 'react-redux'
 
 InitMocks()
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, ...rest }: AppProps) {
+  const { store, props } = wrapper.useWrappedStore(rest)
   return (
     <>
-      <Component {...pageProps} />
+      <Provider store={store}>
+        <Component {...props.pageProps} />
+      </Provider>
       <ToastContainer />
     </>
   )
 }
 
-export default wrapper.withRedux(MyApp)
+export default MyApp

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,18 @@
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import InitMocks from '@/mocks'
-import wrapper from '@/store'
+import store from '@/store'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 import { Provider } from 'react-redux'
 
 InitMocks()
 
-function MyApp({ Component, ...rest }: AppProps) {
-  const { store, props } = wrapper.useWrappedStore(rest)
+function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Provider store={store}>
-        <Component {...props.pageProps} />
+        <Component {...pageProps} />
       </Provider>
       <ToastContainer />
     </>

--- a/store/clubCreation.test.ts
+++ b/store/clubCreation.test.ts
@@ -1,4 +1,4 @@
-import { store } from '@/store'
+import store from '@/store'
 import { addActivityImg, setClubType } from './clubCreation'
 
 describe('clubCreation store test', () => {

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,4 +1,9 @@
-import { AnyAction, combineReducers, configureStore } from '@reduxjs/toolkit'
+import {
+  AnyAction,
+  combineReducers,
+  configureStore,
+  Store,
+} from '@reduxjs/toolkit'
 import { createWrapper, HYDRATE } from 'next-redux-wrapper'
 
 import clubCreationSlice from './clubCreation'
@@ -38,7 +43,7 @@ const makeStore = () => {
   })
 }
 
-const wrapper = createWrapper(makeStore, { debug: NODE_ENV })
+const wrapper = createWrapper<Store<RootState>>(makeStore, { debug: NODE_ENV })
 
 export const store = makeStore()
 export default wrapper

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,10 +1,4 @@
-import {
-  AnyAction,
-  combineReducers,
-  configureStore,
-  Store,
-} from '@reduxjs/toolkit'
-import { createWrapper, HYDRATE } from 'next-redux-wrapper'
+import { configureStore } from '@reduxjs/toolkit'
 
 import clubCreationSlice from './clubCreation'
 import clubCreationPageSlice from './clubCreationPage'
@@ -15,35 +9,20 @@ import clubDetailSlice from './clubDetail'
 
 const NODE_ENV = process.env.NODE_ENV === 'development'
 
-const rootReducer = combineReducers({
-  clubCreation: clubCreationSlice.reducer,
-  clubCreationPage: clubCreationPageSlice.reducer,
-  imgs: ImgsSlice.reducer,
-  user: userSlice.reducer,
-  applicant: applicantSlice.reducer,
-  clubDetail: clubDetailSlice.reducer,
+const store = configureStore({
+  reducer: {
+    clubCreation: clubCreationSlice.reducer,
+    clubCreationPage: clubCreationPageSlice.reducer,
+    imgs: ImgsSlice.reducer,
+    user: userSlice.reducer,
+    applicant: applicantSlice.reducer,
+    clubDetail: clubDetailSlice.reducer,
+  },
+  devTools: NODE_ENV,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
 })
-export type RootState = ReturnType<typeof rootReducer>
 
-const reducer = (state: RootState | undefined, action: AnyAction) => {
-  switch (action.type) {
-    case HYDRATE:
-      return { ...state, ...action.payload }
-    default:
-      return rootReducer(state, action)
-  }
-}
+export type RootState = ReturnType<typeof store.getState>
 
-const makeStore = () => {
-  return configureStore({
-    reducer,
-    devTools: NODE_ENV,
-    middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware({ serializableCheck: false }),
-  })
-}
-
-const wrapper = createWrapper<Store<RootState>>(makeStore, { debug: NODE_ENV })
-
-export const store = makeStore()
-export default wrapper
+export default store

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,11 +3839,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next-redux-wrapper@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-8.1.0.tgz#d9c135f1ceeb2478375bdacd356eb9db273d3a07"
-  integrity sha512-2hIau0hcI6uQszOtrvAFqgc0NkZegKYhBB7ZAKiG3jk7zfuQb4E7OV9jfxViqqojh3SEHdnFfPkN9KErttUKuw==
-
 next@13.1.6:
   version "13.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-13.1.6.tgz#054babe20b601f21f682f197063c9b0b32f1a27c"


### PR DESCRIPTION
## 💡 개요

`next-redux-wrapper` 라이브러리가 업데이트 되면서 레거시를 제거하게 되었습니다

## 🙋‍♂️ 질문사항

개발 초반에는 `next-redux-wrapper`를 사용할 줄 알고 추가를 했지만
ssr을 제대로 사용하지 않아서 `next-redux-wrapper`가 필요가 없어졌습니다
때문에 이 라이브러리를 제거를 하는 게 좋을까요? 아니면 나중을 위해 남겨 두는 게 좋을까요?