### PR TITLE
🔀 useEffect eslint 에러 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": ["node_modules/**", "**/dist/**"],
   "rules": {
+    "react-hooks/exhaustive-deps": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {


### PR DESCRIPTION
## 💡 개요

useEffect에서 생기는 eslint dependency 에러를 제거했습니다
제거 이유는 딱히 필요도 없는 에러 같고 지키느라 오히려 재렌더링이 더 많아져 페이지가 느려지는 현상이 발생해 지우게 되었습니다