### PR TITLE
🔀 동아리 생성 후 store 값 초기화 기능 추가

### DIFF
--- a/components/ClubCreationModal/Page/AddClubMember.tsx
+++ b/components/ClubCreationModal/Page/AddClubMember.tsx
@@ -3,7 +3,8 @@ import { RootState } from '@/store'
 import { MemberType } from '@/type/common'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+import { clearClubData } from '@/store/clubCreation'
 import Input from '@/components/Common/Input'
 import Member from '../Common/Member'
 import SelectUserList from '../Common/SelectUserList'
@@ -15,6 +16,7 @@ interface Props {
 }
 
 const AddClubMember = ({ onClose }: Props) => {
+  const dispatch = useDispatch()
   const { clubCreation } = useSelector((state: RootState) => ({
     clubCreation: state.clubCreation,
   }))
@@ -26,7 +28,10 @@ const AddClubMember = ({ onClose }: Props) => {
   const { fetch: addClub, isLoading } = useFetch({
     url: '/club',
     method: 'post',
-    onSuccess: onClose,
+    onSuccess: () => {
+      dispatch(clearClubData())
+      onClose()
+    },
   })
 
   useEffect(() => {

--- a/store/clubCreation.test.ts
+++ b/store/clubCreation.test.ts
@@ -1,5 +1,5 @@
 import store from '@/store'
-import { addActivityImg, setClubType } from './clubCreation'
+import { addActivityImg, clearClubData, setClubType } from './clubCreation'
 
 describe('clubCreation store test', () => {
   it('club type should be undefined', () => {
@@ -33,6 +33,22 @@ describe('clubCreation store test', () => {
     expect(() =>
       store.dispatch(addActivityImg(['1', '2', '3', '4', '5']))
     ).toThrow(Error('Activity image maximum count is 4'))
+  })
+
+  it('should clear all data', () => {
+    store.dispatch(clearClubData())
+    const { clubCreation } = store.getState()
+
+    expect(clubCreation).toEqual({
+      type: 'MAJOR',
+      name: '',
+      content: '',
+      bannerImg: '',
+      contact: '',
+      notionLink: '',
+      activityImgs: [],
+      member: [],
+    })
   })
 })
 

--- a/store/clubCreation.ts
+++ b/store/clubCreation.ts
@@ -54,17 +54,7 @@ const clubCreationSlice = createSlice({
     },
 
     clearClubData: (state) => {
-      state = {
-        type: 'MAJOR',
-        name: '',
-        content: '',
-        bannerImg: '',
-        contact: '',
-        notionLink: '',
-        activityImgs: [],
-        member: [],
-        teacher: undefined,
-      }
+      state = initialState
       return state
     },
   },

--- a/store/clubCreation.ts
+++ b/store/clubCreation.ts
@@ -63,6 +63,7 @@ const clubCreationSlice = createSlice({
         notionLink: '',
         activityImgs: [],
         member: [],
+        teacher: undefined,
       }
       return state
     },

--- a/store/clubCreation.ts
+++ b/store/clubCreation.ts
@@ -52,6 +52,20 @@ const clubCreationSlice = createSlice({
     removeMember: (state, action: PayloadAction<string>) => {
       state.member = state.member.filter((i) => i.uuid !== action.payload)
     },
+
+    clearClubData: (state) => {
+      state = {
+        type: 'MAJOR',
+        name: '',
+        content: '',
+        bannerImg: '',
+        contact: '',
+        notionLink: '',
+        activityImgs: [],
+        member: [],
+      }
+      return state
+    },
   },
 })
 
@@ -63,6 +77,7 @@ export const {
   removeMember,
   setBannerImg,
   addActivityImg,
+  clearClubData,
 } = clubCreationSlice.actions
 
 export default clubCreationSlice


### PR DESCRIPTION
## 💡 개요

동아리 생성 후 store 값 초기화하는 기능을 추가했습니다

## 📃 작업내용

- 동아리 값 초기화 action 추가
- action 테스트 코드 추가
- 페이지에 action 실행 기능 추가