### PR TITLE
Interceptors header 변경

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -17,7 +17,7 @@ API.interceptors.request.use(async (config) => {
   )
     await tokenManager.tokenReissue()
 
-  config.headers['Authorization'] = `Bearer ${tokenManager.accessToken}`
+  config.headers['Authorization'] = `Bearer ${tokenManager.accessToken ?? ''}`
 
   return config
 })

--- a/api/index.ts
+++ b/api/index.ts
@@ -17,7 +17,9 @@ API.interceptors.request.use(async (config) => {
   )
     await tokenManager.tokenReissue()
 
-  config.headers['Authorization'] = `Bearer ${tokenManager.accessToken ?? ''}`
+  config.headers['Authorization'] = tokenManager.accessToken
+    ? `Bearer ${tokenManager.accessToken}`
+    : undefined
 
   return config
 })


### PR DESCRIPTION
## 💡 개요
api요청 보내는데 401이뜨는 버그를 발견하였다
버그 원인을 찾던중 
``` js
config.headers['Authorization'] = "Bearer ${이상한값(null,error,wtf...)}"
```
일때 문제가 발생하는것을 찾았다
## 📃 작업내용
```js
config.headers['Authorization'] = `Bearer ${tokenManager.accessToken ?? ''}`
```

## 🎸 기타
localhost에서 CORS이슈가 있어서 테스트할수 없어 insomnia,modheader(개발자도구에서 헤더를 직접 수정할수있는 크롬 확장프로그램 무조건 다운로드ㄱㄱ)등을 이용한 테스트 밖에 할 수 없어 제대로 작동하는지 알수 없음

