### PR TITLE
🔀동아리 리스트 컴포넌트에 호버시 커서추가

### DIFF
--- a/components/ClubList/style.ts
+++ b/components/ClubList/style.ts
@@ -12,6 +12,7 @@ export const ClubOptionLayer = styled.form`
     display: none;
   }
   input[type='radio'] + label {
+    cursor: pointer;
     width: 49px;
     height: 24px;
     display: flex;
@@ -40,6 +41,7 @@ export const ClubList = styled.div`
 `
 
 export const ClubItem = styled.div`
+  cursor: pointer;
   margin-top: 17px;
   width: 163.75px;
   aspect-ratio: auto 1 / 1.378;


### PR DESCRIPTION
## 💡 개요
동아리 리스트 컴포넌트에서 클릭 이벤트가 있는 컴포넌트에 호버시 커서가 되지않아 
유저에게 혼란을 줄것을 우려하여 수정을 결심했다.
## 📃 작업내용
동아리 리스트 컴포넌트 스타일 수정
