### PR TITLE
🔀 refreshToken이 만료 되었을 때의 처리

### DIFF
--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -43,6 +43,7 @@ class TokenManager {
 
       return true
     } catch (e) {
+      window.location.href = '/'
       return false
     }
   }

--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -44,6 +44,7 @@ class TokenManager {
 
       return true
     } catch (e) {
+      this.removeTokens()
       window.location.href = '/'
       return false
     }

--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -3,12 +3,13 @@ import { TokensType } from '@/type/api/TokenManager'
 import axios from 'axios'
 
 class TokenManager {
-  private _accessToken: string | null
-  private _refreshToken: string | null
-  private _accessExp: string | null
-  private _refreshExp: string | null
+  private _accessToken: string | null = null
+  private _refreshToken: string | null = null
+  private _accessExp: string | null = null
+  private _refreshExp: string | null = null
 
   constructor() {
+    if (typeof window === undefined) return
     this._accessToken = localStorage.getItem(accessToken)
     this._refreshToken = localStorage.getItem(refreshToken)
     this._accessExp = localStorage.getItem(accessExp)


### PR DESCRIPTION
## 💡 개요

refreshToken 값이 만료되었을 때 모든 토큰을 지우고 메인 페이지로 redirect 하게 변경했습니다

## 📃 작업내용

- 토큰 재발급에 실패시 모든 토큰을 지우고 메인 페이지로 redirect
- 생성자에서 window 객체 검증