### PR TITLE
🔀 동아리 디테일 페이지 SSR 적용

### DIFF
--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -9,7 +9,7 @@ class TokenManager {
   private _refreshExp: string | null = null
 
   constructor() {
-    if (typeof window === undefined) return
+    if (typeof window === 'undefined') return
     this._accessToken = localStorage.getItem(accessToken)
     this._refreshToken = localStorage.getItem(refreshToken)
     this._accessExp = localStorage.getItem(accessExp)

--- a/components/DetailPage/index.tsx
+++ b/components/DetailPage/index.tsx
@@ -1,10 +1,5 @@
-import { useFetch } from '@/hooks'
 import { RootState } from '@/store'
-import { setClubDetail } from '@/store/clubDetail'
-import { ClubDetailType } from '@/type/common'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import SEO from '../SEO'
 import ClubActivity from './ClubActivity'
 import ClubMember from './ClubMember'
@@ -15,37 +10,18 @@ import SideBar from './SideBar'
 import * as S from './style'
 
 export default function DetailPage() {
-  const router = useRouter()
-  const clubID = router.query.clubID?.toString()
-  const dispatch = useDispatch()
-
   const { clubDetail } = useSelector((state: RootState) => ({
     clubDetail: state.clubDetail,
   }))
 
-  const { fetch, data } = useFetch<ClubDetailType>({
-    url: `/club/${clubID}`,
-    method: 'get',
-    onSuccess: (data) => {
-      dispatch(setClubDetail(data))
-    },
-    errors: {
-      400: '동아리 아이디를 찾을수 없습니다.',
-    },
-  })
-
-  useEffect(() => {
-    if (clubID) fetch()
-  }, [clubID])
-
   return (
     <>
       <SEO
-        title={`GCMS | ${data?.name}`}
-        description={data?.content}
-        image={data?.bannerImg}
+        title={`GCMS | ${clubDetail.name}`}
+        description={clubDetail.content}
+        image={clubDetail.bannerImg}
       />
-      {data && (
+      {clubDetail.id && (
         <S.Layout>
           <S.Wrapper>
             <S.Section>

--- a/components/DetailPage/index.tsx
+++ b/components/DetailPage/index.tsx
@@ -21,24 +21,22 @@ export default function DetailPage() {
         description={clubDetail.content}
         image={clubDetail.bannerImg}
       />
-      {clubDetail.id && (
-        <S.Layout>
-          <S.Wrapper>
-            <S.Section>
-              <S.ClubBanner src={clubDetail.bannerImg} />
-              <S.ClubInfo>
-                <ClubName />
-                <Contact />
-                <Description />
-              </S.ClubInfo>
-              <ClubActivity />
-              <ClubMember />
-            </S.Section>
-            <SideBar />
-          </S.Wrapper>
-          <S.Footer />
-        </S.Layout>
-      )}
+      <S.Layout>
+        <S.Wrapper>
+          <S.Section>
+            <S.ClubBanner src={clubDetail.bannerImg} />
+            <S.ClubInfo>
+              <ClubName />
+              <Contact />
+              <Description />
+            </S.ClubInfo>
+            <ClubActivity />
+            <ClubMember />
+          </S.Section>
+          <SideBar />
+        </S.Wrapper>
+        <S.Footer />
+      </S.Layout>
     </>
   )
 }

--- a/components/SEO/index.tsx
+++ b/components/SEO/index.tsx
@@ -32,8 +32,9 @@ const SEO = ({
 
       <meta name='twitter:title' content={title} />
       <meta name='twitter:description' content={description} />
-      <meta name='twitter:card' content='summary' />
-      <meta name='twitter:site' content={url} />
+      <meta name='twitter:card' content='summary_large_image' />
+      <meta name='twitter:site' content={title} />
+      <meta name='twitter:url' content={url} />
       <meta name='twitter:image' content={image} />
     </Head>
   )

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@reduxjs/toolkit": "^1.9.2",
     "axios": "^1.2.6",
     "next": "13.1.6",
+    "next-redux-wrapper": "^8.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,19 @@
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import InitMocks from '@/mocks'
-import store from '@/store'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 import { Provider } from 'react-redux'
+import wrapper from '@/store'
 
 InitMocks()
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, ...rest }: AppProps) {
+  const { store, props } = wrapper.useWrappedStore(rest)
   return (
     <>
       <Provider store={store}>
-        <Component {...pageProps} />
+        <Component {...props.pageProps} />
       </Provider>
       <ToastContainer />
     </>

--- a/pages/detail/[clubID].tsx
+++ b/pages/detail/[clubID].tsx
@@ -1,7 +1,31 @@
+import API from '@/api'
 import DetailPage from '@/components/DetailPage'
 import Header from '@/components/Header'
+import wrapper from '@/store'
+import { setClubDetail } from '@/store/clubDetail'
+import { ClubDetailType } from '@/type/common'
 
-export default function Detail() {
+export const getServerSideProps = wrapper.getServerSideProps(
+  (store) => async (ctx) => {
+    try {
+      const { data } = await API.get<ClubDetailType>(
+        `/club/${ctx.query.clubID}`
+      )
+      store.dispatch(setClubDetail(data))
+    } catch (e) {
+      return { props: { ok: false } }
+    }
+
+    return { props: { ok: true } }
+  }
+)
+
+interface Props {
+  ok: boolean
+}
+
+export default function Detail({ ok }: Props) {
+  if (!ok) return 'falied'
   return (
     <>
       <Header />

--- a/store/clubCreation.test.ts
+++ b/store/clubCreation.test.ts
@@ -1,4 +1,4 @@
-import store from '@/store'
+import { store } from '@/store'
 import { addActivityImg, clearClubData, setClubType } from './clubCreation'
 
 describe('clubCreation store test', () => {

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit'
+import { configureStore, combineReducers, AnyAction } from '@reduxjs/toolkit'
 
 import clubCreationSlice from './clubCreation'
 import clubCreationPageSlice from './clubCreationPage'
@@ -7,24 +7,40 @@ import userSlice from './user'
 import applicantSlice from './applicant'
 import clubDetailSlice from './clubDetail'
 import loginModalSlice from './loginModal'
+import { createWrapper, HYDRATE } from 'next-redux-wrapper'
 
 const NODE_ENV = process.env.NODE_ENV === 'development'
 
-const store = configureStore({
-  reducer: {
-    clubCreation: clubCreationSlice.reducer,
-    clubCreationPage: clubCreationPageSlice.reducer,
-    imgs: ImgsSlice.reducer,
-    user: userSlice.reducer,
-    applicant: applicantSlice.reducer,
-    clubDetail: clubDetailSlice.reducer,
-    loginModal: loginModalSlice.reducer,
-  },
-  devTools: NODE_ENV,
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({ serializableCheck: false }),
+const rootReducer = combineReducers({
+  clubCreation: clubCreationSlice.reducer,
+  clubCreationPage: clubCreationPageSlice.reducer,
+  imgs: ImgsSlice.reducer,
+  user: userSlice.reducer,
+  applicant: applicantSlice.reducer,
+  clubDetail: clubDetailSlice.reducer,
+  loginModal: loginModalSlice.reducer,
 })
 
-export type RootState = ReturnType<typeof store.getState>
+const reducer = (state: RootState | undefined, action: AnyAction) => {
+  switch (action.type) {
+    case HYDRATE:
+      return { ...state, ...action.payload }
+    default:
+      return rootReducer(state, action)
+  }
+}
 
-export default store
+const makeStore = () => {
+  return configureStore({
+    reducer,
+    devTools: NODE_ENV,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }),
+  })
+}
+
+export type RootState = ReturnType<typeof rootReducer>
+export const store = makeStore()
+
+const wrapper = createWrapper(makeStore, { debug: NODE_ENV })
+export default wrapper

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,6 +3839,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+next-redux-wrapper@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-8.1.0.tgz#d9c135f1ceeb2478375bdacd356eb9db273d3a07"
+  integrity sha512-2hIau0hcI6uQszOtrvAFqgc0NkZegKYhBB7ZAKiG3jk7zfuQb4E7OV9jfxViqqojh3SEHdnFfPkN9KErttUKuw==
+
 next@13.1.6:
   version "13.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-13.1.6.tgz#054babe20b601f21f682f197063c9b0b32f1a27c"


### PR DESCRIPTION
## 💡 개요

동아리 디테일 페이지의 twitter card를 위해 ssr을 적용했습니다

## 📃 작업내용

- next-redux-wrapper 부활
- `pages/detail/[clubID]`에 getServerSideProps 추가