### PR TITLE
동아리 신청자 리스트 부장에게 권한이 없는 문제 해결

### DIFF
--- a/components/ApplicantPage/UserList/index.tsx
+++ b/components/ApplicantPage/UserList/index.tsx
@@ -9,11 +9,7 @@ export default function UserList({ data, value }: UserListProps) {
         {data?.applicantList.map(
           (item) =>
             item.name.includes(value) && (
-              <UserItem
-                item={item}
-                key={item.uuid}
-                userScope={data.userScope}
-              />
+              <UserItem item={item} key={item.uuid} userScope={data.scope} />
             )
         )}
       </S.UserContainer>

--- a/components/ApplicantPage/index.tsx
+++ b/components/ApplicantPage/index.tsx
@@ -43,7 +43,7 @@ export default function ApplicantPage() {
             register={register('value')}
           />
         </S.InputBox>
-        {data?.userScope === 'HEAD' && (
+        {data?.scope === 'HEAD' && (
           <>
             <SelectedUserImg selected={applicant} />
             <S.AllSelectBox>
@@ -56,7 +56,7 @@ export default function ApplicantPage() {
           </>
         )}
         <UserList data={data} value={watch('value').trim()} />
-        {data?.userScope === 'HEAD' && <ChoiceUser />}
+        {data?.scope === 'HEAD' && <ChoiceUser />}
       </S.Layer>
     </S.Positioner>
   )

--- a/mocks/handlers/api/applicant/[clubID]/get.ts
+++ b/mocks/handlers/api/applicant/[clubID]/get.ts
@@ -3,7 +3,7 @@ import { ApplicantListType } from '@/type/common'
 import { rest } from 'msw'
 
 const headData: ApplicantListType = {
-  userScope: 'HEAD',
+  scope: 'HEAD',
   applicantList: [
     {
       uuid: '12038',
@@ -81,7 +81,7 @@ const headData: ApplicantListType = {
 }
 
 const memberData: ApplicantListType = {
-  userScope: 'MEMBER',
+  scope: 'MEMBER',
   applicantList: [
     {
       uuid: '12038',

--- a/type/common/ApplicantListType.ts
+++ b/type/common/ApplicantListType.ts
@@ -1,7 +1,7 @@
 import MemberType from './MemberType'
 
 interface ApplicantListType {
-  userScope: 'MEMBER' | 'HEAD'
+  scope: 'MEMBER' | 'HEAD'
   applicantList: MemberType[]
 }
 


### PR DESCRIPTION
## 💡 개요
``` json
{
	"userScope":"HEAD" | "MEMBER",
	"applicantList":[
		{
			"uuid": "uuid",
			"email": "s21031",
			"name": "유저이름",
			"grade": 1,
			"classNum": 2,
			"number": 3,
			"profileImg": "대충 프로필 이미지 url", // optional
		},
		{
			"uuid": "uuid",
			"email": "s21031",
			"name": "유저이름",
			"grade": 1,
			"classNum": 2,
			"number": 3,
			"profileImg": "대충 프로필 이미지 url", // optional
		},
	]
}
```
api 명세서의 오타로 인해 `userScope -> scope`로 고쳐야합니다



## 📃 작업내용
동아리 신청자 리스트 api type 수정