### PR TITLE
🔀 동아리 페이지 리셋 기능 추가

### DIFF
--- a/components/ClubCreationModal/Page/AddClubMember.tsx
+++ b/components/ClubCreationModal/Page/AddClubMember.tsx
@@ -10,6 +10,7 @@ import Member from '../Common/Member'
 import SelectUserList from '../Common/SelectUserList'
 import SubmitButton from '../Common/SubmitButton'
 import * as S from './AddClubMember.style'
+import { resetPage } from '@/store/clubCreationPage'
 
 interface Props {
   onClose: () => void
@@ -30,6 +31,7 @@ const AddClubMember = ({ onClose }: Props) => {
     method: 'post',
     onSuccess: () => {
       dispatch(clearClubData())
+      dispatch(resetPage())
       onClose()
     },
   })

--- a/store/clubCreationPage.ts
+++ b/store/clubCreationPage.ts
@@ -12,6 +12,9 @@ const clubCreationPageSlice = createSlice({
       if (state <= 1) throw new Error('There is no previous page')
       return (state -= 1)
     },
+    resetPage: () => {
+      return 1
+    },
   },
 })
 

--- a/store/clubCreationPage.ts
+++ b/store/clubCreationPage.ts
@@ -18,5 +18,5 @@ const clubCreationPageSlice = createSlice({
   },
 })
 
-export const { nextPage, backPage } = clubCreationPageSlice.actions
+export const { nextPage, backPage, resetPage } = clubCreationPageSlice.actions
 export default clubCreationPageSlice


### PR DESCRIPTION
## 💡 개요

동아리 생성 후 페이지가 그대로 남아있는 문제가 발생했습니다

## 📃 작업내용

페이지 리셋 기능을 추가하고 적용까지했습니다
