### PR TITLE
🔀 Club Member 페이지 권한 이슈 해결

### DIFF
--- a/components/ClubMemberPage/UserList/UserItem.tsx
+++ b/components/ClubMemberPage/UserList/UserItem.tsx
@@ -58,10 +58,12 @@ export default function UserItem({ item, scope }: MemberItemProps) {
           )}
         </S.CheckBox>
       </S.UserBox>
-      <S.OptionBox>
-        <S.OptionBtn onClick={() => onKick(item.uuid)}>추방</S.OptionBtn>
-        <S.OptionBtn onClick={() => onDelegate(item.uuid)}>위임</S.OptionBtn>
-      </S.OptionBox>
+      {item.scope !== 'HEAD' && (
+        <S.OptionBox>
+          <S.OptionBtn onClick={() => onKick(item.uuid)}>추방</S.OptionBtn>
+          <S.OptionBtn onClick={() => onDelegate(item.uuid)}>위임</S.OptionBtn>
+        </S.OptionBox>
+      )}
     </S.UserWrapper>
   )
 }


### PR DESCRIPTION
## 💡 개요
club member 페이지에서 부장 권한을 가진 유저가 자기 자신을 동아리 추방 또는 부장 위임을 할 수 있는 이슈를 발견했습니다
## 📃 작업내용
동아리 멤버 중 부장 권한을 가진 멤버는 option button을 띄우지 않도록 수정했습니다

