### PR TITLE
🔀 토큰 재발급 중복 요청 문제 해결

### DIFF
--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -27,7 +27,7 @@ class TokenManager {
       !this.validateToken(this._refreshExp, this._refreshToken) ||
       this.addMinuteDate(refreshTime, 1) >= new Date()
     )
-      return refreshToken
+      return refreshTime
 
     const res = await this.refreshQuery()
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -6,6 +6,8 @@ const API = axios.create({
   withCredentials: true,
 })
 
+let refreshTime = ''
+
 API.interceptors.request.use(async (config) => {
   const tokenManager = new TokenManager()
 
@@ -15,7 +17,7 @@ API.interceptors.request.use(async (config) => {
       tokenManager.accessToken
     )
   )
-    await tokenManager.tokenReissue()
+    refreshTime = await tokenManager.tokenReissue(refreshTime)
 
   config.headers['Authorization'] = tokenManager.accessToken
     ? `Bearer ${tokenManager.accessToken}`


### PR DESCRIPTION
## 💡 개요

토큰 재발급 중복 요청 문제를 해결합니다

## 📃 작업내용

- refreshTime이라는 변수를 만들어 토큰을 재발급 할 때 마다 요청한 시간을 할당해 줍니다
- 토큰 재발급 요청이 동시에 일어날 경우 1분 이내에 재발급 요청이 있었는지를 판단해 재발급 요청을 취소합니다