### PR TITLE
🔀 동아리 지원자 목록 페이지에서 undefined 요청을 날리는 문제를 해결했습니다

### DIFF
--- a/components/ApplicantPage/index.tsx
+++ b/components/ApplicantPage/index.tsx
@@ -16,8 +16,9 @@ import { useRouter } from 'next/router'
 
 export default function ApplicantPage() {
   const router = useRouter()
+  const clubId = router.query.clubID
   const { fetch, data } = useFetch<ApplicantListType>({
-    url: `/applicant/${router.query.clubID}`,
+    url: `/applicant/${clubId}`,
     method: 'get',
   })
   const { applicant } = useSelector((state: RootState) => ({
@@ -27,8 +28,8 @@ export default function ApplicantPage() {
   const { register, watch } = useForm({ defaultValues: { value: '' } })
 
   useEffect(() => {
-    fetch()
-  }, [fetch])
+    if (clubId) fetch()
+  }, [clubId])
 
   return (
     <S.Positioner>

--- a/components/Common/ClubNav/index.tsx
+++ b/components/Common/ClubNav/index.tsx
@@ -7,22 +7,22 @@ import { ClubDetailType } from '@/type/common'
 
 export default function ClubNav() {
   const router = useRouter()
-  const clubID = router.query.clubID
+  const clubId = router.query.clubID
 
   const { fetch, data } = useFetch<ClubDetailType>({
-    url: `/club/${clubID}`,
+    url: `/club/${clubId}`,
     method: 'get',
   })
 
   useEffect(() => {
-    fetch()
-  }, [fetch])
+    if (clubId) fetch()
+  }, [clubId])
 
   return (
     <S.Layer>
       <h3>{data?.name ?? ''}</h3>
       <S.NavContainer>
-        <S.NavWrapper href={`/applicant/${clubID}`}>
+        <S.NavWrapper href={`/applicant/${clubId}`}>
           <S.IconBox>
             <SVG.MemoPadIcon />
           </S.IconBox>
@@ -30,7 +30,7 @@ export default function ClubNav() {
             <small>신청자 목록</small>
           </S.NavTitle>
         </S.NavWrapper>
-        <S.NavWrapper href={`/member/${clubID}`}>
+        <S.NavWrapper href={`/member/${clubId}`}>
           <S.IconBox>
             <SVG.PersonIcon />
           </S.IconBox>
@@ -38,7 +38,7 @@ export default function ClubNav() {
             <small>동아리 멤버</small>
           </S.NavTitle>
         </S.NavWrapper>
-        <S.NavWrapper href={`/edit/${clubID}`}>
+        <S.NavWrapper href={`/edit/${clubId}`}>
           <S.IconBox>
             <SVG.School />
           </S.IconBox>


### PR DESCRIPTION
## 💡 개요

undefined query를 2번 날리는 문제를 해결했습니다

## 📃 작업내용

요청을 보내는 useEffet에서 clubId 값이 있을 때만 요청을 보낼 수 있도록 수정했습니다