### PR TITLE
🔀 accessToken 과 accessExp 값이 모두 만료가 되었을 때의 문제 해결

### DIFF
--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -8,11 +8,7 @@ class TokenManager {
   private _refreshExp: string | null = null
 
   constructor() {
-    if (typeof window === 'undefined') return
-    this._accessToken = localStorage.getItem(accessToken)
-    this._refreshToken = localStorage.getItem(refreshToken)
-    this._accessExp = localStorage.getItem(accessExp)
-    this._refreshExp = localStorage.getItem(refreshExp)
+    this.initToken()
   }
 
   validateToken(expiredString: string | null, token: string | null): boolean {
@@ -26,6 +22,14 @@ class TokenManager {
     expiredAt.setMinutes(expiredAt.getMinutes() - addMinute)
 
     return expiredAt
+  }
+
+  initToken() {
+    if (typeof window === 'undefined') return
+    this._accessToken = localStorage.getItem(accessToken)
+    this._refreshToken = localStorage.getItem(refreshToken)
+    this._accessExp = localStorage.getItem(accessExp)
+    this._refreshExp = localStorage.getItem(refreshExp)
   }
 
   setTokens(tokens: TokensType) {

--- a/api/index.ts
+++ b/api/index.ts
@@ -21,7 +21,8 @@ API.interceptors.request.use(async (config) => {
       tokenManager.refreshToken
     )
   ) {
-    await store.dispatch(reissueToken(store.getState().reissue))
+    await store.dispatch(reissueToken())
+    tokenManager.initToken()
   }
 
   config.headers['Authorization'] = tokenManager.accessToken

--- a/lib/delay.ts
+++ b/lib/delay.ts
@@ -1,0 +1,7 @@
+const delay = async (ms: number) => {
+  return await new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export default delay

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -7,7 +7,7 @@ import { RootState } from '.'
 import delay from '@/lib/delay'
 
 export const reissueToken = createAsyncThunk(
-  'api/refreshToken',
+  'reissue/reissueToken',
   async (_, { getState, dispatch }) => {
     const tokenManager = new TokenManager()
     const { reissue } = getState() as RootState

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -17,7 +17,7 @@ export const reissueToken = createAsyncThunk(
       tokenManager.calculatMinutes(reissue.refreshDate, 1) >= new Date()
     ) {
       while ((getState() as RootState).reissue.isLoading) {
-        await delay(10)
+        await delay(100)
       }
       return
     }

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -44,6 +44,7 @@ const reissueSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder.addCase(reissueToken.pending, (state) => {
+      state.refreshDate = new Date().toString()
       state.isLoading = true
     })
     builder.addCase(reissueToken.fulfilled, (state) => {


### PR DESCRIPTION
## 💡 개요

accessToken 과 accessExp 값이 모두 만료가 되었을 때의 문제 발생

auth 요청과 동시에 user와 club 값을 가져오기 때문에 auth의 response 값을 받지 않은 상태로 user와 club 요청을 해버리는 것이다
때문에 user와 club은 만료된 상태의 토큰을 보내게 되고 모두 401이 뜨게 된다

<img width="204" alt="스크린샷 2023-02-26 오전 2 01 16" src="https://user-images.githubusercontent.com/57276315/221369818-5305e8f0-1309-4a07-b83d-7af191407394.png">

## 📃 작업내용

이 문제를 해결하기 위해 토큰 값을 보내는 중에는 api 요청이 멈추도록 하였다

`store/reissue.ts`
<img width="402" alt="스크린샷 2023-02-26 오전 2 14 00" src="https://user-images.githubusercontent.com/57276315/221370417-56fd8931-d9b7-4505-b3ae-78b093fc0cb3.png">

isLoading 값이 false가 될 때 까지 while문을 무한으로 도는 로직이다

## 🔀 변경사항

- TokenManager에 initToken 메소드를 추가

## 🙋‍♂️ 질문사항

> 무한 while 이거 과연 괜찮을까...