### PR TITLE
🔀 동아리 리스트 페이지 SSR 적용

### DIFF
--- a/components/ClubList/index.tsx
+++ b/components/ClubList/index.tsx
@@ -1,22 +1,16 @@
 import ClubItem from './ClubItem'
 import * as S from './style'
-import { ClubListType } from '@/type/common'
-import { useFetch } from '@/hooks'
-import { useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useSelector } from 'react-redux'
+import { RootState } from '@/store'
 
 export default function ClubList() {
   const router = useRouter()
   const clubType = router.query.type?.toString()
-
-  const { fetch, data } = useFetch<ClubListType[]>({
-    url: `/club?type=${clubType || 'MAJOR'}`,
-    method: 'get',
-    errors: {
-      400: '해당 동아리 정보를 찾을수 없습니다.',
-    },
-  })
+  const { clubList } = useSelector((state: RootState) => ({
+    clubList: state.clubList,
+  }))
 
   const pushQuery = (e: React.ChangeEvent<HTMLInputElement>) => {
     const clubValue = e.target.value
@@ -25,10 +19,6 @@ export default function ClubList() {
       query: clubValue && { type: encodeURI(clubValue) },
     })
   }
-
-  useEffect(() => {
-    fetch()
-  }, [clubType])
 
   return (
     <S.ClubWrapper>
@@ -59,14 +49,11 @@ export default function ClubList() {
         <label htmlFor={'EDITORIAL'}>사설</label>
       </S.ClubOptionLayer>
       <S.ClubList>
-        {data &&
-          data.map((i) => {
-            return (
-              <Link key={i.id} href={`detail/${i.id}`}>
-                <ClubItem club={i} />
-              </Link>
-            )
-          })}
+        {clubList.map((i) => (
+          <Link key={i.id} href={`detail/${i.id}`}>
+            <ClubItem club={i} />
+          </Link>
+        ))}
       </S.ClubList>
     </S.ClubWrapper>
   )

--- a/pages/detail/[clubID].tsx
+++ b/pages/detail/[clubID].tsx
@@ -1,6 +1,7 @@
 import API from '@/api'
 import DetailPage from '@/components/DetailPage'
 import Header from '@/components/Header'
+import NotFoundPage from '@/components/NotFoundPage'
 import { useFetch } from '@/hooks'
 import wrapper from '@/store'
 import { setClubDetail, setIsApplied, setScope } from '@/store/clubDetail'
@@ -46,7 +47,7 @@ export default function Detail({ ok }: Props) {
     if (ok && clubId) fetch()
   }, [clubId])
 
-  if (!ok) return 'falied'
+  if (!ok) return <NotFoundPage />
 
   return (
     <>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,35 @@
+import API from '@/api'
 import Header from '@/components/Header'
 import MainPage from '@/components/MainPage'
+import NotFoundPage from '@/components/NotFoundPage'
 import SEO from '@/components/SEO'
+import wrapper from '@/store'
+import { setClubList } from '@/store/clubList'
+import { ClubListType } from '@/type/common'
 
-export default function Home() {
+export const getServerSideProps = wrapper.getServerSideProps(
+  (store) => async (ctx) => {
+    const clubType = ctx.query?.type
+    try {
+      const { data } = await API.get<ClubListType[]>(
+        `/club?type=${clubType || 'MAJOR'}`
+      )
+      store.dispatch(setClubList(data))
+    } catch (e) {
+      return { props: { ok: false } }
+    }
+
+    return { props: { ok: true } }
+  }
+)
+
+interface Props {
+  ok: boolean
+}
+
+export default function Home({ ok }: Props) {
+  if (!ok) return <NotFoundPage />
+
   return (
     <>
       <SEO title='GCMS' />

--- a/store/clubList.ts
+++ b/store/clubList.ts
@@ -1,0 +1,19 @@
+import { ClubListType } from '@/type/common'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+const initialState: ClubListType[] = []
+
+const clubListSlice = createSlice({
+  name: 'clubList',
+  initialState,
+  reducers: {
+    setClubList: (state, { payload }: PayloadAction<ClubListType[]>) => {
+      state = payload
+      return state
+    },
+  },
+})
+
+export const { setClubList } = clubListSlice.actions
+
+export default clubListSlice

--- a/store/index.ts
+++ b/store/index.ts
@@ -9,6 +9,7 @@ import clubDetailSlice from './clubDetail'
 import loginModalSlice from './loginModal'
 import { createWrapper, HYDRATE } from 'next-redux-wrapper'
 import reissueSlice from './reissue'
+import clubListSlice from './clubList'
 
 const NODE_ENV = process.env.NODE_ENV === 'development'
 
@@ -21,6 +22,7 @@ const rootReducer = combineReducers({
   clubDetail: clubDetailSlice.reducer,
   loginModal: loginModalSlice.reducer,
   reissue: reissueSlice.reducer,
+  clubList: clubListSlice.reducer,
 })
 
 const reducer = (state: RootState | undefined, action: AnyAction) => {


### PR DESCRIPTION
## 💡 개요

동아리 리스트 페이지에 SSR을 적용했습니다

## 📃 작업내용

- getServerSideProps를 통해 동아리 정보를 가져옵니다
- 동아리 정보를 가져오는데 실패를 하면 404 페이지를 띄웁니다
- 가져온 동아리 리스트 정보는 redux로 보내져 useSelector를 통해 조회가 가능합니다