### PR TITLE
🔀 useLogin routing 방식 수정

### DIFF
--- a/hooks/useLogin.tsx
+++ b/hooks/useLogin.tsx
@@ -18,10 +18,10 @@ const useLogin = () => {
         tokenManager.setTokens(data)
       }
       fetchUser()
-      router.push('')
+      router.replace('')
     },
     onFailure: () => {
-      router.push('')
+      router.replace('')
     },
   })
 


### PR DESCRIPTION
## 💡 개요
로그아웃 한 상태에서 페이지 뒤로가기를 여러 번 실행했을 때 main 페이지에 query로 code 받아온 시점으로 돌아가면 api가 실행하여 token을 가져오는 현상을 발견했습니다

이슈를 발견하는 방법은 #132 를 참고하세요
## 📃 작업내용
useLogin에 성공 혹은 실패하면 router replace를 해주어 기록에 남지 않게 해주었습니다