### PR TITLE
🔀 header의 유저 정보가 사라지는 문제 해결

### DIFF
--- a/store/index.ts
+++ b/store/index.ts
@@ -28,7 +28,7 @@ const rootReducer = combineReducers({
 const reducer = (state: RootState | undefined, action: AnyAction) => {
   switch (action.type) {
     case HYDRATE:
-      return { ...state, ...action.payload }
+      return { ...state, ...action.payload, user: { ...state?.user } }
     default:
       return rootReducer(state, action)
   }


### PR DESCRIPTION
## 💡 개요

유저 정보가 값자기 사라지는 문제 해결

## 🛑 문제 발생 원인

HYDRATE action이 발생하면 모든 state값이 다시 써지는데
그때 user 값까지 다시 써져버리는 바람에 header의 값이 사라짐

## 📃 작업내용

next reducer에서 user 값이 지워지지 않도록 유지 시킴