### PR TITLE
🔀 동아리 페이지 새로고침 시 undefind 쿼리 이슈 해결

### DIFF
--- a/components/ClubMemberPage/index.tsx
+++ b/components/ClubMemberPage/index.tsx
@@ -9,17 +9,18 @@ import Input from '../Common/Input'
 import * as S from './style'
 import UserList from './UserList'
 
-export default function ApplicantPage() {
+export default function ClubMemberPage() {
   const router = useRouter()
+  const clubId = router.query.clubID
   const { fetch, data } = useFetch<MemberListType>({
-    url: `/club-member/${router.query.clubID}`,
+    url: `/club-member/${clubId}`,
     method: 'get',
   })
   const { register, watch } = useForm({ defaultValues: { value: '' } })
 
   useEffect(() => {
-    fetch()
-  }, [])
+    if (clubId) fetch()
+  }, [clubId])
 
   return (
     <S.Positioner>


### PR DESCRIPTION
## 💡 개요
동아리 멤버 페이지에서 새로고침 할 때 query의 clubId가 undefind일 때 api 요청을 하여 이슈가 발생했습니다
## 📃 작업내용
clubId가 존재할 때 api 요청을 하도록 수정했습니다