### PR TITLE
디테일 페이지 멤버 리스트 스타일 수정

### DIFF
--- a/components/DetailPage/style.ts
+++ b/components/DetailPage/style.ts
@@ -234,7 +234,7 @@ export const MemberProfile = styled(Image)`
   object-fit: cover;
   object-position: center;
   background: #c4c4c4;
-  flex: 0 0 auto;
+  flex-shrink: 0;
 `
 
 export const SampelIMG = styled.div`
@@ -242,7 +242,7 @@ export const SampelIMG = styled.div`
   background: #c4c4c4;
   height: 48px;
   border-radius: 50%;
-  flex: 0 0 auto;
+  flex-shrink: 0;
 `
 
 export const Footer = styled.footer`

--- a/components/DetailPage/style.ts
+++ b/components/DetailPage/style.ts
@@ -195,8 +195,7 @@ export const ClubMember = styled.div`
     }
   }
   @media (max-width: 750px) {
-    width: 90%;
-    margin: 0 auto;
+    width: 100%;
     margin-top: 60px;
   }
 `
@@ -235,6 +234,7 @@ export const MemberProfile = styled(Image)`
   object-fit: cover;
   object-position: center;
   background: #c4c4c4;
+  flex: 0 0 auto;
 `
 
 export const SampelIMG = styled.div`
@@ -242,6 +242,7 @@ export const SampelIMG = styled.div`
   background: #c4c4c4;
   height: 48px;
   border-radius: 50%;
+  flex: 0 0 auto;
 `
 
 export const Footer = styled.footer`

--- a/components/DetailPage/style.ts
+++ b/components/DetailPage/style.ts
@@ -234,7 +234,7 @@ export const MemberProfile = styled(Image)`
   object-fit: cover;
   object-position: center;
   background: #c4c4c4;
-  flex-shrink: 0;
+  flex: none;
 `
 
 export const SampelIMG = styled.div`
@@ -242,7 +242,7 @@ export const SampelIMG = styled.div`
   background: #c4c4c4;
   height: 48px;
   border-radius: 50%;
-  flex-shrink: 0;
+  flex: none;
 `
 
 export const Footer = styled.footer`

--- a/components/DetailPage/style.ts
+++ b/components/DetailPage/style.ts
@@ -15,6 +15,7 @@ export const Wrapper = styled.div`
   width: 700px;
   display: flex;
   justify-content: space-between;
+  margin-top: 42px;
   @media (max-width: 750px) {
     width: 100%;
     flex-direction: column;
@@ -23,7 +24,6 @@ export const Wrapper = styled.div`
 `
 export const Section = styled.section`
   width: 510px;
-  margin-top: 42px;
   @media (max-width: 750px) {
     width: 100%;
   }
@@ -252,9 +252,9 @@ export const Footer = styled.footer`
 `
 
 export const SideBar = styled.div`
-  position: absolute;
+  position: sticky;
   right: 0;
-  top: 42px;
+  top: 72px;
   width: 174px;
   height: 224px;
   background: #242425;


### PR DESCRIPTION
## 💡 개요
* 디테일 페이지에서 멤버리스트 반응형시 왼쪽에서 살짝 멀어지는 이슈가 생김
* 멤버 프로필중 이미지가 없는 sample이미지 반응형시 크기가 자동으로 줄어드는 이슈 발생
* 사이드바가 스크롤시 같이 내려오는게 사용자에게 편리할것이라고 판단함

## 📃 작업내용
* 멤버리스트 크기 수정
* 프로필 컴포넌트 style에 flex-shrink: 0 추가
* 사이드바 포지션 스타일 수정
![image](https://user-images.githubusercontent.com/81688137/221477203-b5867643-bbae-45d6-a6d3-29ddf7dc4cc2.png)

![image](https://user-images.githubusercontent.com/81688137/221479059-8b18907c-bdf9-4afe-adb0-d49d45d18996.png)
