### PR TITLE
🔀 마이페이지 클럽리스트 클릭 범위 수정

### DIFF
--- a/components/MyPage/ClubItem/index.tsx
+++ b/components/MyPage/ClubItem/index.tsx
@@ -10,22 +10,20 @@ export default function ClubItem({ clubType, data }: ClubItemType) {
       {data?.clubs.map((item) => {
         if (item.type === clubType)
           return (
-            <Link href={`/detail/${item.id}`}>
-              <S.ClubItem key={item.id}>
-                <S.ClubImg>
-                  <Image
-                    src={item.bannerImg}
-                    alt='bannerImg'
-                    width={50}
-                    height={50}
-                  />
-                </S.ClubImg>
-                <S.ClubName>{item.name}</S.ClubName>
-                <Link href={`/applicant/${item.id}`}>
-                  <SVG.KebabMenuIcon />
-                </Link>
-              </S.ClubItem>
-            </Link>
+            <S.ClubItem href={`/detail/${item.id}`} key={item.id}>
+              <S.ClubImg>
+                <Image
+                  src={item.bannerImg}
+                  alt='bannerImg'
+                  width={50}
+                  height={50}
+                />
+              </S.ClubImg>
+              <S.ClubName>{item.name}</S.ClubName>
+              <Link href={`/applicant/${item.id}`}>
+                <SVG.KebabMenuIcon />
+              </Link>
+            </S.ClubItem>
           )
       })}
     </>

--- a/components/MyPage/ClubItem/style.ts
+++ b/components/MyPage/ClubItem/style.ts
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
+import Link from 'next/link'
 import { ClubType, ProfileImg } from '../style'
 
-export const ClubItem = styled.div`
+export const ClubItem = styled(Link)`
   width: 350px;
   height: 56px;
   background: #2d2d2d;


### PR DESCRIPTION
## 💡 개요
마이페이지에서 클럽리스트 클릭시 디테일 페이지로 가는데 아이템 범위가 너무 넓어 컴포넌트 범위 밖에서도 클릭이 가능한 오류 발생

## 📃 작업내용
아이템을 감싸는 태그를 link태그로 수정
