### PR TITLE
🔀 멤버페이지에서 디테일 가는 링크 추가

### DIFF
--- a/components/Common/ClubNav/index.tsx
+++ b/components/Common/ClubNav/index.tsx
@@ -20,7 +20,9 @@ export default function ClubNav() {
 
   return (
     <S.Layer>
-      <h3>{data?.name ?? ''}</h3>
+      <div>
+        <S.ClubName href={`/detail/${clubId}`}>{data?.name ?? ''}</S.ClubName>
+      </div>
       <S.NavContainer>
         <S.NavWrapper href={`/applicant/${clubId}`}>
           <S.IconBox>

--- a/components/Common/ClubNav/style.ts
+++ b/components/Common/ClubNav/style.ts
@@ -8,6 +8,19 @@ export const Layer = styled.div`
   margin-bottom: 20px;
 `
 
+export const ClubName = styled(Link)`
+  display: inline;
+  height: 20px;
+  font-weight: 700;
+  font-size: 17px;
+  color: #fcffff;
+  transition: 0.3s;
+
+  :hover {
+    color: #4164e1;
+  }
+`
+
 export const NavContainer = styled.div`
   display: flex;
   gap: 40px;


### PR DESCRIPTION
## 💡 개요
디테일 페이지에서 멤버페이지로 갈수 있지만 반대로 갈수가 없어 사용자가 불편함을 느낄것이라고 판단

## 📃 작업내용
* clubnav clubname에 링크 추가
