### PR TITLE
🔀 디테일페이지 동아리 멤버 리스트 이미지 추가

### DIFF
--- a/components/DetailPage/ClubMember.tsx
+++ b/components/DetailPage/ClubMember.tsx
@@ -38,19 +38,21 @@ export default function ClubMember() {
         </S.HeadProfile>
       </div>
       <span>
-        {clubDetail.member?.map((data) =>
-          data.profileImg ? (
-            <S.MemberProfile
-              key={data.uuid}
-              alt='member progile img'
-              src={data.profileImg}
-              width={48}
-              height={48}
-            />
-          ) : (
-            <S.SampelIMG key={data.uuid} />
-          )
-        )}
+        {clubDetail.member?.map((data) => (
+          <S.MemberWrapper key={data.uuid}>
+            {data.profileImg ? (
+              <S.MemberProfile
+                alt='member progile img'
+                src={data.profileImg}
+                width={48}
+                height={48}
+              />
+            ) : (
+              <S.SampelIMG key={data.uuid} />
+            )}
+            <p>{data.name}</p>
+          </S.MemberWrapper>
+        ))}
       </span>
     </S.ClubMember>
   )

--- a/components/DetailPage/style.ts
+++ b/components/DetailPage/style.ts
@@ -182,7 +182,7 @@ export const ClubMember = styled.div`
     gap: 26px;
   }
   > span {
-    margin-top: 20px;
+    margin-top: 42px;
     width: 100%;
     display: flex;
     gap: 9px;
@@ -224,6 +224,16 @@ export const HeadInfo = styled.div`
   span {
     font-weight: 500;
     font-size: 13px;
+  }
+`
+export const MemberWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  p {
+    font-size: 13px;
+    line-height: 16px;
+    color: rgba(255, 255, 255, 0.5);
   }
 `
 


### PR DESCRIPTION
## 💡 개요
디테일 페이지 멤버 리스트에서 디폴트 이미지로는 유저를 구별 할 수 없어서 이름을 추가해주었다.
## 📃 작업내용
* 이름 컴포넌트 추가
<img width="655" alt="image" src="https://user-images.githubusercontent.com/81688137/223737174-b88d0d2d-9619-4f8e-8a27-5a68f4d5a0d2.png">

반응형
<img width="422" alt="image" src="https://user-images.githubusercontent.com/81688137/223737265-f92fe76a-05b0-47ab-bb93-24b0c72f3896.png">


