### PR TITLE
🔀 동아리 이름이 길 때 처리

### DIFF
--- a/components/ClubList/style.ts
+++ b/components/ClubList/style.ts
@@ -66,7 +66,8 @@ export const ClubItem = styled.div`
   aspect-ratio: auto 1 / 1.378;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 1rem;
+
   @media (max-width: 800px) {
     width: 180px;
   }
@@ -90,13 +91,16 @@ export const ClubImg = styled.div`
 `
 
 export const ClubTitle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
   h3 {
     font-weight: 600;
     font-size: 15px;
     margin: 0;
   }
   p {
-    margin: 8px 0 0 0;
     width: 100%;
     font-weight: 500;
     font-size: 12px;


### PR DESCRIPTION
## 💡 개요

동아리 이름이 길면 이미지와의 간격이 사라지는 문제 해결

## 📃 작업내용

club card의 style 수정

## 🔀 변경사항

![스크린샷 2023-03-12 오후 3 43 15](https://user-images.githubusercontent.com/57276315/224528899-5236ee1b-ad25-4c2b-9d6f-c32929b0170f.png)

## 🎸 기타

- 동아리 이름에 길이 제한을 두면 좋을 것 같음
