### PR TITLE
🔀 confirm modal 추가

### DIFF
--- a/components/ApplicantPage/ChoiceUser/index.tsx
+++ b/components/ApplicantPage/ChoiceUser/index.tsx
@@ -1,8 +1,9 @@
+import ConfirmModal from '@/components/Common/ConfirmModal'
 import { useFetch } from '@/hooks'
 import { RootState } from '@/store'
 import { removeUser } from '@/store/applicant'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import * as S from './style'
 
@@ -16,6 +17,7 @@ export default function ChoiceUser({ onSubmit }: choiceUserProps) {
   }))
   const dispatch = useDispatch()
   const [choice, setChoice] = useState('')
+  const [isShow, setIsShow] = useState<boolean>(false)
   const router = useRouter()
   const { fetch: data } = useFetch({
     url: `/applicant/${router.query.clubID}/${choice}`,
@@ -23,23 +25,36 @@ export default function ChoiceUser({ onSubmit }: choiceUserProps) {
     onSuccess: onSubmit,
   })
 
-  const onFetch = () => {
+  const onClick = (choice: string) => {
+    setChoice(choice)
+    setIsShow(true)
+  }
+
+  const onConfirm = () => {
     applicant.forEach(async (item) => {
       await data({ uuid: item.uuid })
       dispatch(removeUser(item.uuid))
     })
   }
 
-  useEffect(() => {
-    if (choice === '') return
-    return onFetch()
-  }, [choice])
   return (
-    <S.Positioner>
-      <S.Layer>
-        <S.RejectBtn onClick={() => setChoice('reject')}>불합격</S.RejectBtn>
-        <S.AcceptBtn onClick={() => setChoice('accept')}>합격</S.AcceptBtn>
-      </S.Layer>
-    </S.Positioner>
+    <>
+      <S.Positioner>
+        <S.Layer>
+          <S.RejectBtn onClick={() => onClick('reject')}>불합격</S.RejectBtn>
+          <S.AcceptBtn onClick={() => onClick('accept')}>합격</S.AcceptBtn>
+        </S.Layer>
+      </S.Positioner>
+      {isShow && (
+        <ConfirmModal
+          title={`지원자 ${choice === 'accept' ? '합격' : '불합격'}`}
+          description={`정말 ${
+            choice === 'accept' ? '합격' : '불합격'
+          }시키겠습니까?`}
+          onClose={() => setIsShow(false)}
+          onConfirm={onConfirm}
+        />
+      )}
+    </>
   )
 }

--- a/components/ApplicantPage/ChoiceUser/index.tsx
+++ b/components/ApplicantPage/ChoiceUser/index.tsx
@@ -19,6 +19,7 @@ export default function ChoiceUser({ onSubmit }: choiceUserProps) {
   const [choice, setChoice] = useState('')
   const [isShow, setIsShow] = useState<boolean>(false)
   const router = useRouter()
+  const passKorean = choice === 'accept' ? '합격' : '불합격'
   const { fetch: data } = useFetch({
     url: `/applicant/${router.query.clubID}/${choice}`,
     method: 'post',
@@ -47,10 +48,8 @@ export default function ChoiceUser({ onSubmit }: choiceUserProps) {
       </S.Positioner>
       {isShow && (
         <ConfirmModal
-          title={`지원자 ${choice === 'accept' ? '합격' : '불합격'}`}
-          description={`정말 ${
-            choice === 'accept' ? '합격' : '불합격'
-          }시키겠습니까?`}
+          title={`지원자 ${passKorean}`}
+          description={`정말 ${passKorean}시키겠습니까?`}
           onClose={() => setIsShow(false)}
           onConfirm={onConfirm}
         />

--- a/components/ClubEdit/components/Notice/ClubLeaveAndDeleteBtn.tsx
+++ b/components/ClubEdit/components/Notice/ClubLeaveAndDeleteBtn.tsx
@@ -1,7 +1,8 @@
 import ConfirmModal from '@/components/Common/ConfirmModal'
 import { useFetch } from '@/hooks'
+import { showModal } from '@/store/confirmModal'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useDispatch } from 'react-redux'
 import * as S from './style'
 
 interface Props {
@@ -11,7 +12,7 @@ interface Props {
 }
 
 const ClubLeaveAndDeleteBtn = ({ clubId, clubName, type }: Props) => {
-  const [isShow, setIsShow] = useState<boolean>(false)
+  const dispatch = useDispatch()
   const router = useRouter()
   const { fetch, isLoading } = useFetch({
     method: 'delete',
@@ -29,16 +30,15 @@ const ClubLeaveAndDeleteBtn = ({ clubId, clubName, type }: Props) => {
   return (
     <>
       <S.Title>동아리 {type}</S.Title>
-      <S.DeleteBtn onClick={() => setIsShow(true)}>{type}하기</S.DeleteBtn>
+      <S.DeleteBtn onClick={() => dispatch(showModal())}>
+        {type}하기
+      </S.DeleteBtn>
 
-      {isShow && (
-        <ConfirmModal
-          title={`동아리 ${type}하기`}
-          description={`${clubName}동아리를 정말로 ${type}하시겠습니까?`}
-          onClose={() => setIsShow(false)}
-          onConfirm={onClick}
-        />
-      )}
+      <ConfirmModal
+        title={`동아리 ${type}하기`}
+        description={`${clubName}동아리를 정말로 ${type}하시겠습니까?`}
+        onConfirm={onClick}
+      />
     </>
   )
 }

--- a/components/ClubEdit/components/Notice/ClubLeaveAndDeleteBtn.tsx
+++ b/components/ClubEdit/components/Notice/ClubLeaveAndDeleteBtn.tsx
@@ -1,8 +1,7 @@
 import ConfirmModal from '@/components/Common/ConfirmModal'
 import { useFetch } from '@/hooks'
-import { showModal } from '@/store/confirmModal'
 import { useRouter } from 'next/router'
-import { useDispatch } from 'react-redux'
+import { useState } from 'react'
 import * as S from './style'
 
 interface Props {
@@ -12,8 +11,8 @@ interface Props {
 }
 
 const ClubLeaveAndDeleteBtn = ({ clubId, clubName, type }: Props) => {
-  const dispatch = useDispatch()
   const router = useRouter()
+  const [isShow, setIsShow] = useState<boolean>(false)
   const { fetch, isLoading } = useFetch({
     method: 'delete',
     url: `/club/${clubId}${type === '탈퇴' ? '/exit' : ''}`,
@@ -30,15 +29,16 @@ const ClubLeaveAndDeleteBtn = ({ clubId, clubName, type }: Props) => {
   return (
     <>
       <S.Title>동아리 {type}</S.Title>
-      <S.DeleteBtn onClick={() => dispatch(showModal())}>
-        {type}하기
-      </S.DeleteBtn>
+      <S.DeleteBtn onClick={() => setIsShow(true)}>{type}하기</S.DeleteBtn>
 
-      <ConfirmModal
-        title={`동아리 ${type}하기`}
-        description={`${clubName}동아리를 정말로 ${type}하시겠습니까?`}
-        onConfirm={onClick}
-      />
+      {isShow && (
+        <ConfirmModal
+          title={`동아리 ${type}하기`}
+          description={`${clubName}동아리를 정말로 ${type}하시겠습니까?`}
+          onConfirm={onClick}
+          onClose={() => setIsShow(false)}
+        />
+      )}
     </>
   )
 }

--- a/components/ClubMemberPage/UserList/DelegateUser.tsx
+++ b/components/ClubMemberPage/UserList/DelegateUser.tsx
@@ -1,0 +1,40 @@
+import ConfirmModal from '@/components/Common/ConfirmModal'
+import { useFetch } from '@/hooks'
+import { showModal } from '@/store/confirmModal'
+import { useDispatch } from 'react-redux'
+import * as S from './style'
+
+interface Props {
+  clubId: string
+  uuid: string
+}
+
+const DelegateUser = ({ clubId, uuid }: Props) => {
+  const dispatch = useDispatch()
+  const { fetch, isLoading } = useFetch({
+    url: `/club-member/${clubId}`,
+    method: 'patch',
+    successMessage: '부장 위임에 성공하셨습니다',
+  })
+
+  const onClick = () => dispatch(showModal())
+
+  const onConfirm = () => {
+    if (isLoading) return
+    fetch({ uuid })
+  }
+
+  return (
+    <>
+      <S.OptionBtn onClick={onClick}>위임</S.OptionBtn>
+
+      <ConfirmModal
+        title='부장 위임'
+        description={'정말로 부장 위임을 하시겠습니까?'}
+        onConfirm={onConfirm}
+      />
+    </>
+  )
+}
+
+export default DelegateUser

--- a/components/ClubMemberPage/UserList/DelegateUser.tsx
+++ b/components/ClubMemberPage/UserList/DelegateUser.tsx
@@ -1,7 +1,6 @@
 import ConfirmModal from '@/components/Common/ConfirmModal'
 import { useFetch } from '@/hooks'
-import { showModal } from '@/store/confirmModal'
-import { useDispatch } from 'react-redux'
+import { useState } from 'react'
 import * as S from './style'
 
 interface Props {
@@ -10,29 +9,33 @@ interface Props {
 }
 
 const DelegateUser = ({ clubId, uuid }: Props) => {
-  const dispatch = useDispatch()
+  const [isShow, setIsShow] = useState<boolean>(false)
   const { fetch, isLoading } = useFetch({
     url: `/club-member/${clubId}`,
     method: 'patch',
     successMessage: '부장 위임에 성공하셨습니다',
   })
 
-  const onClick = () => dispatch(showModal())
+  const onClick = () => setIsShow(true)
 
   const onConfirm = () => {
     if (isLoading) return
     fetch({ uuid })
+    setIsShow(false)
   }
 
   return (
     <>
       <S.OptionBtn onClick={onClick}>위임</S.OptionBtn>
 
-      <ConfirmModal
-        title='부장 위임'
-        description={'정말로 부장 위임을 하시겠습니까?'}
-        onConfirm={onConfirm}
-      />
+      {isShow && (
+        <ConfirmModal
+          title='부장 위임'
+          description={'정말로 부장 위임을 하시겠습니까?'}
+          onConfirm={onConfirm}
+          onClose={() => setIsShow(false)}
+        />
+      )}
     </>
   )
 }

--- a/components/ClubMemberPage/UserList/KickUser.tsx
+++ b/components/ClubMemberPage/UserList/KickUser.tsx
@@ -1,7 +1,6 @@
 import ConfirmModal from '@/components/Common/ConfirmModal'
 import { useFetch } from '@/hooks'
-import { showModal } from '@/store/confirmModal'
-import { useDispatch } from 'react-redux'
+import { useState } from 'react'
 import * as S from './style'
 
 interface Props {
@@ -10,29 +9,33 @@ interface Props {
 }
 
 const KickUser = ({ clubId, uuid }: Props) => {
-  const dispatch = useDispatch()
+  const [isShow, setIsShow] = useState<boolean>(false)
   const { fetch, isLoading } = useFetch({
     url: `/club-member/${clubId}`,
     method: 'post',
     successMessage: '회원 추방에 성공하셨습니다',
   })
 
-  const onClick = () => dispatch(showModal())
+  const onClick = () => setIsShow(true)
 
-  const onConfirm = () => {
+  const onConfirm = async () => {
     if (isLoading) return
-    fetch({ uuid })
+    await fetch({ uuid })
+    setIsShow(false)
   }
 
   return (
     <>
       <S.OptionBtn onClick={onClick}>추방</S.OptionBtn>
 
-      <ConfirmModal
-        title='회원 추방'
-        description={'정말로 회원 추방을 하시겠습니까?'}
-        onConfirm={onConfirm}
-      />
+      {isShow && (
+        <ConfirmModal
+          title='회원 추방'
+          description={'정말로 회원 추방을 하시겠습니까?'}
+          onConfirm={onConfirm}
+          onClose={() => setIsShow(false)}
+        />
+      )}
     </>
   )
 }

--- a/components/ClubMemberPage/UserList/KickUser.tsx
+++ b/components/ClubMemberPage/UserList/KickUser.tsx
@@ -1,0 +1,40 @@
+import ConfirmModal from '@/components/Common/ConfirmModal'
+import { useFetch } from '@/hooks'
+import { showModal } from '@/store/confirmModal'
+import { useDispatch } from 'react-redux'
+import * as S from './style'
+
+interface Props {
+  clubId: string
+  uuid: string
+}
+
+const KickUser = ({ clubId, uuid }: Props) => {
+  const dispatch = useDispatch()
+  const { fetch, isLoading } = useFetch({
+    url: `/club-member/${clubId}`,
+    method: 'post',
+    successMessage: '회원 추방에 성공하셨습니다',
+  })
+
+  const onClick = () => dispatch(showModal())
+
+  const onConfirm = () => {
+    if (isLoading) return
+    fetch({ uuid })
+  }
+
+  return (
+    <>
+      <S.OptionBtn onClick={onClick}>추방</S.OptionBtn>
+
+      <ConfirmModal
+        title='회원 추방'
+        description={'정말로 회원 추방을 하시겠습니까?'}
+        onConfirm={onConfirm}
+      />
+    </>
+  )
+}
+
+export default KickUser

--- a/components/ClubMemberPage/UserList/UserItem.tsx
+++ b/components/ClubMemberPage/UserList/UserItem.tsx
@@ -1,49 +1,14 @@
-import ConfirmModal from '@/components/Common/ConfirmModal'
-import { useFetch } from '@/hooks'
-import { showModal } from '@/store/confirmModal'
-import ConfirmStateType from '@/type/common/ConfirmStateType'
 import { MemberItemProps } from '@/type/components/MemberPage'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { useDispatch } from 'react-redux'
+import KickUser from './KickUser'
 import * as S from './style'
+import DelegateUser from './DelegateUser'
+import { useState } from 'react'
 
 export default function UserItem({ item, scope }: MemberItemProps) {
   const router = useRouter()
-  const clubID = router.query.clubID
-  const dispatch = useDispatch()
+  const clubID = router.query.clubID?.toString() || ''
   const [isSelected, setSelected] = useState<boolean>(false)
-  const [uuid, setUuid] = useState<string>('')
-  const [confirmState, setConfirmState] = useState<ConfirmStateType>({
-    title: '',
-    description: '',
-  })
-
-  const { fetch: kick } = useFetch({
-    url: `/club-member/${clubID}`,
-    method: 'post',
-    successMessage: '회원 추방에 성공하셨습니다',
-  })
-
-  const { fetch: delegate } = useFetch({
-    url: `/club-member/${clubID}`,
-    method: 'patch',
-    successMessage: '부장 위임에 성공하셨습니다',
-  })
-
-  const onClick = (title: string, description: string, uuid: string) => {
-    setConfirmState({
-      title,
-      description,
-    })
-    setUuid(uuid)
-    dispatch(showModal())
-  }
-
-  const onConfirm = () => {
-    if (confirmState.title === '회원 추방') kick({ uuid })
-    else delegate({ uuid })
-  }
 
   return (
     <>
@@ -61,7 +26,7 @@ export default function UserItem({ item, scope }: MemberItemProps) {
             </small>
           </S.UserInfo>
           <S.CheckBox>
-            {scope === 'HEAD' && item.scope !== 'HEAD' && (
+            {['HEAD', 'ADMIN'].includes(scope) && item.scope !== 'HEAD' && (
               <>
                 <S.CheckBtn
                   id={item.uuid}
@@ -77,35 +42,10 @@ export default function UserItem({ item, scope }: MemberItemProps) {
           </S.CheckBox>
         </S.UserBox>
         <S.OptionBox>
-          <S.OptionBtn
-            onClick={() =>
-              onClick(
-                '회원 추방',
-                '정말로 회원 추방을 하시겠습니까?',
-                item.uuid
-              )
-            }
-          >
-            추방
-          </S.OptionBtn>
-          <S.OptionBtn
-            onClick={() =>
-              onClick(
-                '부장 위임',
-                '정말로 부장 위임을 하시겠습니까?',
-                item.uuid
-              )
-            }
-          >
-            위임
-          </S.OptionBtn>
+          <KickUser clubId={clubID} uuid={item.uuid} />
+          <DelegateUser clubId={clubID} uuid={item.uuid} />
         </S.OptionBox>
       </S.UserWrapper>
-      <ConfirmModal
-        title={confirmState.title}
-        description={confirmState.description}
-        onConfirm={onConfirm}
-      />
     </>
   )
 }

--- a/components/ClubMemberPage/UserList/UserItem.tsx
+++ b/components/ClubMemberPage/UserList/UserItem.tsx
@@ -1,13 +1,23 @@
+import ConfirmModal from '@/components/Common/ConfirmModal'
 import { useFetch } from '@/hooks'
+import { showModal } from '@/store/confirmModal'
+import ConfirmStateType from '@/type/common/ConfirmStateType'
 import { MemberItemProps } from '@/type/components/MemberPage'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { useDispatch } from 'react-redux'
 import * as S from './style'
 
 export default function UserItem({ item, scope }: MemberItemProps) {
   const router = useRouter()
   const clubID = router.query.clubID
+  const dispatch = useDispatch()
   const [isSelected, setSelected] = useState<boolean>(false)
+  const [uuid, setUuid] = useState<string>('')
+  const [confirmState, setConfirmState] = useState<ConfirmStateType>({
+    title: '',
+    description: '',
+  })
 
   const { fetch: kick } = useFetch({
     url: `/club-member/${clubID}`,
@@ -21,47 +31,81 @@ export default function UserItem({ item, scope }: MemberItemProps) {
     successMessage: '부장 위임에 성공하셨습니다',
   })
 
-  const onKick = async (uuid: string) => {
-    const isConfirm = confirm(`정말로 회원 추방을 하시겠습니까?`)
-    if (isConfirm) await kick({ uuid: uuid })
+  const onClick = (title: string, description: string, uuid: string) => {
+    setConfirmState({
+      title,
+      description,
+    })
+    setUuid(uuid)
+    dispatch(showModal())
   }
 
-  const onDelegate = async (uuid: string) => {
-    const isConfirm = confirm(`정말로 부장 위임을 하시겠습니까?`)
-    if (isConfirm) await delegate({ uuid: uuid })
+  const onConfirm = () => {
+    if (confirmState.title === '회원 추방') kick({ uuid })
+    else delegate({ uuid })
   }
+
   return (
-    <S.UserWrapper>
-      <S.UserBox option={isSelected}>
-        <S.UserImgBox>
-          {item.profileImg && <S.Img src={item.profileImg} alt='profileImg' />}
-        </S.UserImgBox>
-        <S.UserInfo>
-          <S.UserName>{item.name}</S.UserName>
-          <small>
-            {item.grade}학년 {item.classNum}반 {item.number}번
-          </small>
-        </S.UserInfo>
-        <S.CheckBox>
-          {scope === 'HEAD' && item.scope !== 'HEAD' && (
-            <>
-              <S.CheckBtn
-                id={item.uuid}
-                type='checkbox'
-                onChange={() => setSelected(!isSelected)}
-                checked={isSelected}
-              />
-              <S.CheckBtnLabel htmlFor={item.uuid}>
-                <span />
-              </S.CheckBtnLabel>
-            </>
-          )}
-        </S.CheckBox>
-      </S.UserBox>
-      <S.OptionBox>
-        <S.OptionBtn onClick={() => onKick(item.uuid)}>추방</S.OptionBtn>
-        <S.OptionBtn onClick={() => onDelegate(item.uuid)}>위임</S.OptionBtn>
-      </S.OptionBox>
-    </S.UserWrapper>
+    <>
+      <S.UserWrapper>
+        <S.UserBox option={isSelected}>
+          <S.UserImgBox>
+            {item.profileImg && (
+              <S.Img src={item.profileImg} alt='profileImg' />
+            )}
+          </S.UserImgBox>
+          <S.UserInfo>
+            <S.UserName>{item.name}</S.UserName>
+            <small>
+              {item.grade}학년 {item.classNum}반 {item.number}번
+            </small>
+          </S.UserInfo>
+          <S.CheckBox>
+            {scope === 'HEAD' && item.scope !== 'HEAD' && (
+              <>
+                <S.CheckBtn
+                  id={item.uuid}
+                  type='checkbox'
+                  onChange={() => setSelected(!isSelected)}
+                  checked={isSelected}
+                />
+                <S.CheckBtnLabel htmlFor={item.uuid}>
+                  <span />
+                </S.CheckBtnLabel>
+              </>
+            )}
+          </S.CheckBox>
+        </S.UserBox>
+        <S.OptionBox>
+          <S.OptionBtn
+            onClick={() =>
+              onClick(
+                '회원 추방',
+                '정말로 회원 추방을 하시겠습니까?',
+                item.uuid
+              )
+            }
+          >
+            추방
+          </S.OptionBtn>
+          <S.OptionBtn
+            onClick={() =>
+              onClick(
+                '부장 위임',
+                '정말로 부장 위임을 하시겠습니까?',
+                item.uuid
+              )
+            }
+          >
+            위임
+          </S.OptionBtn>
+        </S.OptionBox>
+      </S.UserWrapper>
+      <ConfirmModal
+        title={confirmState.title}
+        description={confirmState.description}
+        onConfirm={onConfirm}
+      />
+    </>
   )
 }

--- a/components/Common/ConfirmModal/index.tsx
+++ b/components/Common/ConfirmModal/index.tsx
@@ -1,18 +1,27 @@
 import Portal from '@/components/Portal'
+import { RootState } from '@/store'
+import { hideModal } from '@/store/confirmModal'
+import { useDispatch, useSelector } from 'react-redux'
 import * as S from './style'
 
 interface Props {
   title: string
   description?: string
   onConfirm: () => void
-  onClose: () => void
 }
 
-const ConfirmModal = ({ title, description, onClose, onConfirm }: Props) => {
+const ConfirmModal = ({ title, description, onConfirm }: Props) => {
+  const dispatch = useDispatch()
+  const { confirmModal } = useSelector((state: RootState) => ({
+    ...state,
+  }))
+
   const onClick = () => {
     onConfirm()
-    onClose()
+    dispatch(hideModal())
   }
+
+  if (!confirmModal) return null
 
   return (
     <Portal>
@@ -20,7 +29,9 @@ const ConfirmModal = ({ title, description, onClose, onConfirm }: Props) => {
         <S.Title>{title}</S.Title>
         <S.Description>{description}</S.Description>
         <S.Buttons>
-          <S.LeftButton onClick={onClose}>취소</S.LeftButton>
+          <S.LeftButton onClick={() => dispatch(hideModal())}>
+            취소
+          </S.LeftButton>
           <S.RightButton onClick={onClick}>확인</S.RightButton>
         </S.Buttons>
       </S.Wrapper>

--- a/components/Common/ConfirmModal/index.tsx
+++ b/components/Common/ConfirmModal/index.tsx
@@ -1,37 +1,26 @@
 import Portal from '@/components/Portal'
-import { RootState } from '@/store'
-import { hideModal } from '@/store/confirmModal'
-import { useDispatch, useSelector } from 'react-redux'
 import * as S from './style'
 
 interface Props {
   title: string
   description?: string
   onConfirm: () => void
+  onClose: () => void
 }
 
-const ConfirmModal = ({ title, description, onConfirm }: Props) => {
-  const dispatch = useDispatch()
-  const { confirmModal } = useSelector((state: RootState) => ({
-    ...state,
-  }))
-
+const ConfirmModal = ({ title, description, onConfirm, onClose }: Props) => {
   const onClick = () => {
     onConfirm()
-    dispatch(hideModal())
+    onClose()
   }
 
-  if (!confirmModal) return null
-
   return (
-    <Portal>
+    <Portal onClose={onClose}>
       <S.Wrapper>
         <S.Title>{title}</S.Title>
         <S.Description>{description}</S.Description>
         <S.Buttons>
-          <S.LeftButton onClick={() => dispatch(hideModal())}>
-            취소
-          </S.LeftButton>
+          <S.LeftButton onClick={onClose}>취소</S.LeftButton>
           <S.RightButton onClick={onClick}>확인</S.RightButton>
         </S.Buttons>
       </S.Wrapper>

--- a/components/Common/ConfirmModal/style.ts
+++ b/components/Common/ConfirmModal/style.ts
@@ -5,6 +5,7 @@ export const Wrapper = styled.div`
   padding-top: 1rem;
   border-radius: 1rem;
   text-align: center;
+  min-width: 20rem;
 `
 
 export const Title = styled.h2`

--- a/components/MyPage/ProfileSetting/index.tsx
+++ b/components/MyPage/ProfileSetting/index.tsx
@@ -1,14 +1,13 @@
 import * as S from './style'
 import { useFetch, useUpload } from '@/hooks'
-import { ChangeEvent, MouseEvent, useEffect, useState } from 'react'
-import { ApiType, OnDeleteType } from '@/type/components/MyPage'
+import { ChangeEvent, useState } from 'react'
+import { OnDeleteType } from '@/type/components/MyPage'
 import { useLoggedIn } from '@/hooks'
 import { useRouter } from 'next/router'
 import TokenManager from '@/api/TokenManager'
 import { useDispatch } from 'react-redux'
 import { removeUser } from '@/store/user'
 import ConfirmModal from '@/components/Common/ConfirmModal'
-import { showModal } from '@/store/confirmModal'
 
 interface profileSetingProps {
   onSubmit: () => void
@@ -17,6 +16,7 @@ interface profileSetingProps {
 export default function ProfileSetting({ onSubmit }: profileSetingProps) {
   const { upload } = useUpload()
   const { isLoggned } = useLoggedIn({})
+  const [isShow, setIsShow] = useState<boolean>(false)
   const [queryState, setQueryState] = useState<OnDeleteType>({
     title: '',
     message: '',
@@ -62,7 +62,7 @@ export default function ProfileSetting({ onSubmit }: profileSetingProps) {
       title,
       message,
     })
-    dispatch(showModal())
+    setIsShow(true)
   }
 
   const onConfirm = () => {
@@ -107,11 +107,14 @@ export default function ProfileSetting({ onSubmit }: profileSetingProps) {
           />
         </S.Layer>
       </S.Positioner>
-      <ConfirmModal
-        title={queryState.title}
-        description={queryState.message}
-        onConfirm={onConfirm}
-      />
+      {isShow && (
+        <ConfirmModal
+          title={queryState.title}
+          description={queryState.message}
+          onConfirm={onConfirm}
+          onClose={() => setIsShow(false)}
+        />
+      )}
     </>
   )
 }

--- a/components/MyPage/ProfileSetting/index.tsx
+++ b/components/MyPage/ProfileSetting/index.tsx
@@ -1,12 +1,14 @@
 import * as S from './style'
 import { useFetch, useUpload } from '@/hooks'
-import { ChangeEvent, useEffect, useState } from 'react'
+import { ChangeEvent, MouseEvent, useEffect, useState } from 'react'
 import { ApiType, OnDeleteType } from '@/type/components/MyPage'
 import { useLoggedIn } from '@/hooks'
 import { useRouter } from 'next/router'
 import TokenManager from '@/api/TokenManager'
 import { useDispatch } from 'react-redux'
 import { removeUser } from '@/store/user'
+import ConfirmModal from '@/components/Common/ConfirmModal'
+import { showModal } from '@/store/confirmModal'
 
 interface profileSetingProps {
   onSubmit: () => void
@@ -15,17 +17,18 @@ interface profileSetingProps {
 export default function ProfileSetting({ onSubmit }: profileSetingProps) {
   const { upload } = useUpload()
   const { isLoggned } = useLoggedIn({})
-  const router = useRouter()
-  const dispatch = useDispatch()
-
-  const [apiConfig, setApiConfig] = useState<ApiType>({
+  const [queryState, setQueryState] = useState<OnDeleteType>({
+    title: '',
+    message: '',
     url: '',
     method: 'get',
   })
+  const router = useRouter()
+  const dispatch = useDispatch()
 
-  const { fetch: Delete } = useFetch({
-    url: apiConfig.url,
-    method: apiConfig.method,
+  const { fetch: deleteQuery } = useFetch({
+    url: queryState.url,
+    method: queryState.method,
     onSuccess: () => {
       const tokenManager = new TokenManager()
       tokenManager.removeTokens()
@@ -52,53 +55,63 @@ export default function ProfileSetting({ onSubmit }: profileSetingProps) {
     })
   }
 
-  const onDelete = ({ url, method, message }: OnDeleteType) => {
-    const confirmCheck = confirm(message)
-    if (confirmCheck) setApiConfig({ url: url, method: method })
+  const onDelete = ({ url, method, title, message }: OnDeleteType) => {
+    setQueryState({
+      url,
+      method,
+      title,
+      message,
+    })
+    dispatch(showModal())
   }
 
-  useEffect(() => {
-    ;(async () => {
-      if (apiConfig.url === '') return
-      await Delete()
-
-      if (!isLoggned) router.replace('/')
-    })()
-  }, [apiConfig])
+  const onConfirm = () => {
+    if (!isLoggned) return
+    deleteQuery()
+  }
 
   return (
-    <S.Positioner>
-      <S.Layer>
-        <S.Btn
-          type='file'
-          accept='image/*'
-          id='imgUpload'
-          onChange={(e) => onChange(e)}
-        />
-        <label htmlFor='imgUpload'>이미지 변경</label>
-        <S.Btn
-          type='button'
-          value='로그아웃'
-          onClick={() =>
-            onDelete({
-              url: '/auth',
-              method: 'delete',
-              message: '정말로 로그아웃을 하시겠습니까?',
-            })
-          }
-        />
-        <S.Btn
-          type='button'
-          value='서비스 탈퇴'
-          onClick={() =>
-            onDelete({
-              url: '/user',
-              method: 'delete',
-              message: '정말로 회원 탈퇴를 하시겠습니까?',
-            })
-          }
-        />
-      </S.Layer>
-    </S.Positioner>
+    <>
+      <S.Positioner>
+        <S.Layer>
+          <S.Btn
+            type='file'
+            accept='image/*'
+            id='imgUpload'
+            onChange={(e) => onChange(e)}
+          />
+          <label htmlFor='imgUpload'>이미지 변경</label>
+          <S.Btn
+            type='button'
+            value='로그아웃'
+            onClick={() =>
+              onDelete({
+                url: '/auth',
+                method: 'delete',
+                title: '로그아웃',
+                message: '정말로 로그아웃을 하시겠습니까?',
+              })
+            }
+          />
+          <S.Btn
+            type='button'
+            value='서비스 탈퇴'
+            onClick={() =>
+              onDelete({
+                url: '/user',
+                method: 'delete',
+                title: '서비스 탈퇴',
+                message: '정말로 회원 탈퇴를 하시겠습니까?',
+              })
+            }
+          />
+        </S.Layer>
+      </S.Positioner>
+      <ConfirmModal
+        title={queryState.title}
+        description={queryState.message}
+        onConfirm={onConfirm}
+      />
+    </>
   )
 }

--- a/components/MyPage/ProfileSetting/index.tsx
+++ b/components/MyPage/ProfileSetting/index.tsx
@@ -66,8 +66,7 @@ export default function ProfileSetting({ onSubmit }: profileSetingProps) {
   }
 
   const onConfirm = () => {
-    if (!isLoggned) return
-    deleteQuery()
+    if (isLoggned) deleteQuery()
   }
 
   return (

--- a/store/confirmModal.ts
+++ b/store/confirmModal.ts
@@ -1,0 +1,22 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+const initialState = false
+
+const confirmModalSlice = createSlice({
+  name: 'confirmModal',
+  initialState,
+  reducers: {
+    showModal: () => {
+      return true
+    },
+    hideModal: () => {
+      return false
+    },
+    toggleModal: (state) => {
+      return !state
+    },
+  },
+})
+
+export const { showModal, hideModal, toggleModal } = confirmModalSlice.actions
+export default confirmModalSlice

--- a/store/index.ts
+++ b/store/index.ts
@@ -11,6 +11,7 @@ import reissueSlice from './reissue'
 import clubListSlice from './clubList'
 import uuidSlice from './uuid'
 import sidebarSlice from './sidebar'
+import confirmModalSlice from './confirmModal'
 
 const NODE_ENV = process.env.NODE_ENV === 'development'
 
@@ -25,6 +26,7 @@ const rootReducer = combineReducers({
   clubList: clubListSlice.reducer,
   uuid: uuidSlice.reducer,
   sidebar: sidebarSlice.reducer,
+  confirmModal: confirmModalSlice.reducer,
 })
 
 const reducer = (state: RootState | undefined, action: AnyAction) => {

--- a/type/common/ConfirmStateType.ts
+++ b/type/common/ConfirmStateType.ts
@@ -1,0 +1,6 @@
+interface ConfirmStateType {
+  title: string
+  description: string
+}
+
+export default ConfirmStateType

--- a/type/components/MyPage.ts
+++ b/type/components/MyPage.ts
@@ -12,6 +12,7 @@ export interface ApiType {
 export interface OnDeleteType {
   url: string
   method: Method
+  title: string
   message: string
 }
 


### PR DESCRIPTION
## 💡 개요

아래와 같은 상황에 confirm modal을 추가했습니다

- 동아리 신청자 합격
- 동아리 신청자 불합격
- 동아리 멤버 추방
- 동아리 멤버 부장 권한 위임
- 로그아웃
- 회원 탈퇴

## 📃 작업내용

<img width="441" alt="스크린샷 2023-03-13 오후 2 03 36" src="https://user-images.githubusercontent.com/57276315/224612399-15afc50d-e852-47a7-942f-084ba3775954.png">

## 🍴 사용방법

- isShow state를 만들어서 true일 때 보이게 한다
- title, description을 넣어준다
- onConfirm에 성공했을 때 함수를 넣어준다
- onClose에 모달을 닫을 함수를 넣어준다

```tsx
       {isShow && (
        <ConfirmModal
          title='회원 추방'
          description={'정말로 회원 추방을 하시겠습니까?'}
          onConfirm={onConfirm}
          onClose={() => setIsShow(false)}
        />
      )}
```