### PR TITLE
🔀 동아리 수정 페이지 디자인 수정

### DIFF
--- a/components/ApplicantPage/style.ts
+++ b/components/ApplicantPage/style.ts
@@ -9,10 +9,10 @@ export const Positioner = styled.div`
 `
 
 export const Layer = styled.div`
-  width: 700px;
+  width: 90%;
+  max-width: 43.75rem;
   display: flex;
   flex-direction: column;
-  padding: 0 20px;
   gap: 12px;
 
   small {
@@ -21,10 +21,6 @@ export const Layer = styled.div`
 
   h3 {
     margin: 0;
-  }
-
-  @media (max-width: 700px) {
-    width: 100%;
   }
 `
 

--- a/components/ClubEdit/components/Notice/style.ts
+++ b/components/ClubEdit/components/Notice/style.ts
@@ -52,6 +52,7 @@ export const Description = styled.p`
 
 export const UtilContent = styled.div`
   height: 100%;
+  margin-top: 1rem;
   display: flex;
   justify-content: start;
   gap: 3rem;
@@ -61,8 +62,8 @@ export const UtilSection = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
   align-items: start;
+  gap: 1rem;
 `
 
 export const SwitchInput = styled.input`
@@ -104,7 +105,7 @@ export const SwitchBtn = styled.span`
 `
 
 export const DeleteBtn = styled.button`
-  height: 2rem;
+  height: 1.5rem;
   padding: 0;
   color: #4164e1;
   border: none;

--- a/components/ClubEdit/components/Notice/style.ts
+++ b/components/ClubEdit/components/Notice/style.ts
@@ -48,6 +48,7 @@ export const Title = styled.h4`
 export const Description = styled.p`
   opacity: 0.51;
   margin: 0.5rem 0;
+  word-break: break-all;
 `
 
 export const UtilContent = styled.div`

--- a/components/ClubEdit/style.ts
+++ b/components/ClubEdit/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 
 export const Wrapper = styled.div`
-  margin: 0 auto 5rem auto;
+  margin: 1.875rem auto 5rem auto;
   width: 90%;
   max-width: 43.75rem;
   display: flex;

--- a/components/ClubMemberPage/style.ts
+++ b/components/ClubMemberPage/style.ts
@@ -9,10 +9,10 @@ export const Positioner = styled.div`
 `
 
 export const Layer = styled.div`
-  width: 700px;
   display: flex;
   flex-direction: column;
-  padding: 0 20px;
+  width: 90%;
+  max-width: 43.75rem;
   gap: 12px;
 
   small {
@@ -21,10 +21,6 @@ export const Layer = styled.div`
 
   h3 {
     margin: 0;
-  }
-
-  @media (max-width: 700px) {
-    width: 100%;
   }
 `
 


### PR DESCRIPTION
## 💡 개요

동아리 수정 페이지의 디자인에 문제가 있어 수정합니다

## 📃 작업내용

- 동아리 수정 페이지에서 header와의 갭을 줬습니다
- 공고 부분의 스타일을 수정했습니다
- 동아리 수정 페이지가 다른 페이지들과 같이 사이즈를 일관성 있게 변경했습니다

## 🔀 변경사항

<img width="1118" alt="스크린샷 2023-03-14 오후 3 57 48" src="https://user-images.githubusercontent.com/57276315/224920312-77d949cb-2e0d-46b6-8201-bdb500a6986f.png">

<img width="763" alt="스크린샷 2023-03-14 오후 4 30 11" src="https://user-images.githubusercontent.com/57276315/224927064-adc248b4-0b75-47d3-b899-899bb2130f1f.png">

## 🎸 기타

동아리 관리자 처리를 하지 못해서 탈퇴 또는 삭제 버튼이 뜨지 않고 아래 수정 부분도 뜨지 않게 되어서 사진이 좀 이상하게 찍힘
이 문제는 다른 pr에서 처리할 거임