### PR TITLE
🔀 동아리 수정 페이지 승인 권한 수정

### DIFF
--- a/components/ClubEdit/index.tsx
+++ b/components/ClubEdit/index.tsx
@@ -36,7 +36,7 @@ const ClubEdit = () => {
 
         <Notice data={data} />
 
-        {data?.scope === 'HEAD' && (
+        {data && ['ADMIN', 'HEAD'].includes(data?.scope) && (
           <Edit
             banner={data.bannerImg}
             activity={data.activityImgs}

--- a/components/ClubEdit/index.tsx
+++ b/components/ClubEdit/index.tsx
@@ -18,7 +18,7 @@ const ClubEdit = () => {
     method: 'get',
     url: `/club/${clubId}`,
     onSuccess: (data) => {
-      if (!['MEMBER', 'HEAD'].includes(data?.scope)) router.push('/')
+      if (!['MEMBER', 'HEAD', 'ADMIN'].includes(data?.scope)) router.push('/')
       const di = new DataInitializer()
       setClubData(di.ClubDetailToEditClubForm(data))
     },

--- a/type/common/ScopeType.ts
+++ b/type/common/ScopeType.ts
@@ -1,3 +1,3 @@
-type ScopeType = 'HEAD' | 'MEMBER' | 'USER' | 'OTHER'
+type ScopeType = 'HEAD' | 'MEMBER' | 'USER' | 'OTHER' | 'ADMIN'
 
 export default ScopeType


### PR DESCRIPTION
## 💡 개요
동아리 수정페이지에 어드민이 들어갈수 없는 이슈

## 📃 작업내용
* 동아리 수정페이지 승인 권한에 어드민 추가
* scope type 어드민 추가
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/81688137/225524961-60ea53b0-0584-4afe-8b83-d1501c114adb.png">

