### PR TITLE
🔀 중복 쿼리 및 서로 다른 컴포넌트 state 불일치 문제

### DIFF
--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -10,13 +10,12 @@ import { useRouter } from 'next/router'
 import { EditClubForm } from '@/type/components/ClubEdit'
 
 interface Props {
-  initialData: Partial<EditClubForm>
+  initialData?: EditClubForm
   banner: string
   activity: string[]
-  updateData: () => Promise<void>
 }
 
-const Edit = ({ initialData, banner, activity, updateData }: Props) => {
+const Edit = ({ initialData, banner, activity }: Props) => {
   const {
     register,
     watch,
@@ -61,7 +60,6 @@ const Edit = ({ initialData, banner, activity, updateData }: Props) => {
       activityImgs,
       bannerImg,
     })
-    await updateData()
   }
 
   return (

--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -4,13 +4,14 @@ import Textarea from '@/components/Common/Textarea'
 import { useForm } from 'react-hook-form'
 import * as S from './style'
 import ClubImgs from '../ClubImgs'
-import { useFetch, useUpload } from '@/hooks'
+import { useUpload } from '@/hooks'
 import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
 import { EditClubForm } from '@/type/components/ClubEdit'
+import { useSetClubDetailMutation } from '@/store/ClubDetailApi'
 
 interface Props {
-  initialData?: EditClubForm
+  initialData: Partial<EditClubForm>
   banner: string
   activity: string[]
 }
@@ -27,14 +28,11 @@ const Edit = ({ initialData, banner, activity }: Props) => {
     shouldUseNativeValidation: true,
   })
   const router = useRouter()
+  const clubId = router.query.clubID?.toString()
   const { upload } = useUpload()
   const [activityImgs, setActivityImgs] = useState<string[]>(activity)
   const [bannerImg, setBannerImg] = useState<string>(banner)
-  const { fetch } = useFetch({
-    method: 'patch',
-    url: `/club/${router.query?.clubID}`,
-    successMessage: '수정에 성공했습니다',
-  })
+  const [mutation] = useSetClubDetailMutation()
 
   const onUpload = async (
     e: ChangeEvent<HTMLInputElement>,
@@ -55,10 +53,13 @@ const Edit = ({ initialData, banner, activity }: Props) => {
   }
 
   const onSubmit = async (form: EditClubForm) => {
-    await fetch({
-      ...form,
-      activityImgs,
-      bannerImg,
+    mutation({
+      clubId,
+      body: {
+        ...form,
+        activityImgs,
+        bannerImg,
+      },
     })
   }
 

--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -9,6 +9,8 @@ import { ChangeEvent, useState } from 'react'
 import { useRouter } from 'next/router'
 import { EditClubForm } from '@/type/components/ClubEdit'
 import { useSetClubDetailMutation } from '@/store/ClubDetailApi'
+import { toast } from 'react-toastify'
+import toastOption from '@/lib/toastOption'
 
 interface Props {
   initialData: Partial<EditClubForm>
@@ -60,6 +62,10 @@ const Edit = ({ initialData, banner, activity }: Props) => {
         activityImgs,
         bannerImg,
       },
+    }).then((res) => {
+      if ('error' in res)
+        return toast.error('동아리 수정에 실패했습니다', toastOption)
+      toast.success('동아리 수정에 성공했습니다', toastOption)
     })
   }
 

--- a/components/ClubEdit/components/Notice/index.tsx
+++ b/components/ClubEdit/components/Notice/index.tsx
@@ -4,7 +4,7 @@ import * as S from './style'
 import SwitchBtn from './SwitchBtn'
 
 interface Props {
-  data: ClubDetailType | null
+  data: ClubDetailType | undefined
 }
 
 const Notice = ({ data }: Props) => {

--- a/components/ClubEdit/index.tsx
+++ b/components/ClubEdit/index.tsx
@@ -1,31 +1,15 @@
-import { useFetch } from '@/hooks'
-import DataInitializer from '@/lib/DataInitializer'
-import ClubDetailType from '@/type/common/ClubDetailType'
-import { EditClubForm } from '@/type/components/ClubEdit'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
 import ClubNav from '../Common/ClubNav'
 import Edit from './components/Edit'
 import Notice from './components/Notice'
 import * as S from './style'
 import SEO from '@/components/SEO'
+import { useGetClubDetailQuery } from '@/store/ClubDetailApi'
 
 const ClubEdit = () => {
   const router = useRouter()
-  const clubId = router.query.clubID
-  const [clubData, setClubData] = useState<Partial<EditClubForm>>({})
-  const { fetch, data } = useFetch<ClubDetailType>({
-    method: 'get',
-    url: `/club/${clubId}`,
-    onSuccess: (data) => {
-      const di = new DataInitializer()
-      setClubData(di.ClubDetailToEditClubForm(data))
-    },
-  })
-
-  useEffect(() => {
-    if (clubId) fetch()
-  }, [clubId])
+  const clubId = router.query.clubID?.toString() || ''
+  const { data } = useGetClubDetailQuery(clubId, { skip: !clubId })
 
   return (
     <>
@@ -36,12 +20,7 @@ const ClubEdit = () => {
         <Notice data={data} />
 
         {data?.scope === 'HEAD' && (
-          <Edit
-            banner={data.bannerImg}
-            activity={data.activityImgs}
-            initialData={clubData}
-            updateData={fetch}
-          />
+          <Edit banner={data.bannerImg} activity={data.activityImgs} />
         )}
       </S.Wrapper>
     </>

--- a/components/ClubEdit/index.tsx
+++ b/components/ClubEdit/index.tsx
@@ -5,6 +5,7 @@ import Notice from './components/Notice'
 import * as S from './style'
 import SEO from '@/components/SEO'
 import { useGetClubDetailQuery } from '@/store/ClubDetailApi'
+import dataInitializer from '@/lib/DataInitializer'
 
 const ClubEdit = () => {
   const router = useRouter()
@@ -20,7 +21,11 @@ const ClubEdit = () => {
         <Notice data={data} />
 
         {data?.scope === 'HEAD' && (
-          <Edit banner={data.bannerImg} activity={data.activityImgs} />
+          <Edit
+            initialData={dataInitializer.ClubDetailToEditClubForm(data)}
+            banner={data.bannerImg}
+            activity={data.activityImgs}
+          />
         )}
       </S.Wrapper>
     </>

--- a/components/Common/ClubNav/index.tsx
+++ b/components/Common/ClubNav/index.tsx
@@ -1,22 +1,12 @@
 import * as SVG from '@/assets/svg'
-import { useFetch } from '@/hooks'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 import * as S from './style'
-import { ClubDetailType } from '@/type/common'
+import { useGetClubDetailQuery } from '@/store/ClubDetailApi'
 
 export default function ClubNav() {
   const router = useRouter()
-  const clubId = router.query.clubID
-
-  const { fetch, data } = useFetch<ClubDetailType>({
-    url: `/club/${clubId}`,
-    method: 'get',
-  })
-
-  useEffect(() => {
-    if (clubId) fetch()
-  }, [clubId])
+  const clubId = router.query.clubID?.toString() || ''
+  const { data } = useGetClubDetailQuery(clubId, { skip: !clubId })
 
   return (
     <S.Layer>

--- a/lib/DataInitializer.ts
+++ b/lib/DataInitializer.ts
@@ -2,6 +2,13 @@ import ClubDetailType from '@/type/common/ClubDetailType'
 import { EditClubForm } from '@/type/components/ClubEdit'
 
 class DataInitializer {
+  static instance: DataInitializer
+
+  constructor() {
+    if (DataInitializer.instance) return DataInitializer.instance
+    DataInitializer.instance = this
+  }
+
   ClubDetailToEditClubForm(data: ClubDetailType): Partial<EditClubForm> {
     return {
       type: data.type,
@@ -15,4 +22,6 @@ class DataInitializer {
   }
 }
 
-export default DataInitializer
+const dataInitializer = new DataInitializer()
+
+export default dataInitializer

--- a/lib/customBaseQuery.ts
+++ b/lib/customBaseQuery.ts
@@ -1,0 +1,30 @@
+import API from '@/api'
+import {
+  BaseQueryFn,
+  FetchArgs,
+  FetchBaseQueryMeta,
+} from '@reduxjs/toolkit/dist/query'
+import { AxiosError, isAxiosError } from 'axios'
+
+const customBaseQuery: BaseQueryFn<
+  FetchArgs,
+  unknown,
+  AxiosError | string,
+  any,
+  FetchBaseQueryMeta
+> = async (args) => {
+  try {
+    const res = await API({
+      method: args.method,
+      url: args.url,
+      data: args.body,
+    })
+
+    return { data: res.data }
+  } catch (error) {
+    if (!isAxiosError(error)) return { error: String(error) }
+    return { error }
+  }
+}
+
+export default customBaseQuery

--- a/store/ClubDetailApi.ts
+++ b/store/ClubDetailApi.ts
@@ -1,0 +1,15 @@
+import { ClubDetailType } from '@/type/common'
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+const clubDetailApi = createApi({
+  reducerPath: 'clubDetailApi',
+  baseQuery: fetchBaseQuery({ baseUrl: process.env.NEXT_PUBLIC_SERVER_URL }),
+  endpoints: (builder) => ({
+    getClubDetail: builder.query<ClubDetailType, string>({
+      query: (clubId: string) => `/club/${clubId}`,
+    }),
+  }),
+})
+
+export const { useGetClubDetailQuery } = clubDetailApi
+export default clubDetailApi

--- a/store/ClubDetailApi.ts
+++ b/store/ClubDetailApi.ts
@@ -3,13 +3,22 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
 const clubDetailApi = createApi({
   reducerPath: 'clubDetailApi',
+  tagTypes: ['clubDetail'],
   baseQuery: fetchBaseQuery({ baseUrl: process.env.NEXT_PUBLIC_SERVER_URL }),
   endpoints: (builder) => ({
     getClubDetail: builder.query<ClubDetailType, string>({
-      query: (clubId: string) => `/club/${clubId}`,
+      query: (clubId) => `/club/${clubId}`,
+      providesTags: (_, __, id) => [{ type: 'clubDetail', id }],
+    }),
+    setClubDetail: builder.mutation({
+      query: ({ clubId, body }) => ({
+        url: `/club/${clubId}`,
+        method: 'PATCH',
+        body,
+      }),
     }),
   }),
 })
 
-export const { useGetClubDetailQuery } = clubDetailApi
+export const { useGetClubDetailQuery, useSetClubDetailMutation } = clubDetailApi
 export default clubDetailApi

--- a/store/ClubDetailApi.ts
+++ b/store/ClubDetailApi.ts
@@ -1,13 +1,14 @@
+import customBaseQuery from '@/lib/customBaseQuery'
 import { ClubDetailType } from '@/type/common'
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { createApi } from '@reduxjs/toolkit/query/react'
 
 const clubDetailApi = createApi({
   reducerPath: 'clubDetailApi',
   tagTypes: ['clubDetail'],
-  baseQuery: fetchBaseQuery({ baseUrl: process.env.NEXT_PUBLIC_SERVER_URL }),
+  baseQuery: customBaseQuery,
   endpoints: (builder) => ({
     getClubDetail: builder.query<ClubDetailType, string>({
-      query: (clubId) => `/club/${clubId}`,
+      query: (clubId) => ({ url: `/club/${clubId}` }),
       providesTags: (_, __, id) => [{ type: 'clubDetail', id }],
     }),
     setClubDetail: builder.mutation({
@@ -16,6 +17,7 @@ const clubDetailApi = createApi({
         method: 'PATCH',
         body,
       }),
+      invalidatesTags: (_, __, arg) => [{ type: 'clubDetail', id: arg.clubId }],
     }),
   }),
 })

--- a/store/index.ts
+++ b/store/index.ts
@@ -12,6 +12,7 @@ import clubListSlice from './clubList'
 import uuidSlice from './uuid'
 import sidebarSlice from './sidebar'
 import confirmModalSlice from './confirmModal'
+import clubDetailApi from './ClubDetailApi'
 
 const NODE_ENV = process.env.NODE_ENV === 'development'
 
@@ -27,6 +28,7 @@ const rootReducer = combineReducers({
   uuid: uuidSlice.reducer,
   sidebar: sidebarSlice.reducer,
   confirmModal: confirmModalSlice.reducer,
+  [clubDetailApi.reducerPath]: clubDetailApi.reducer,
 })
 
 const reducer = (state: RootState | undefined, action: AnyAction) => {
@@ -43,7 +45,9 @@ const makeStore = () => {
     reducer,
     devTools: NODE_ENV,
     middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware({ serializableCheck: false }),
+      getDefaultMiddleware({ serializableCheck: false }).concat(
+        clubDetailApi.middleware
+      ),
   })
 }
 


### PR DESCRIPTION
## 💡 개요

- 동아리 수정 페이지에서 중복 query를 날리는 것을 확인했습니다
- 동아리 이름이 수정 되어도 맨 위에 있는 title은 변경되지 않는 문제를 발견했습니다

## 📃 작업내용

- rtk query도입
- ClubNav와 Notice, Edit 컴포넌트가 같은 state를 사용하도록 변경

## 🎸 기타

- 에러 메시지 관리를 해야 할 듯