### PR TITLE
🔀 스크롤바 제거

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -94,6 +94,15 @@ body {
   background: #1c1c1e;
 }
 
+body::-webkit-scrollbar {
+  display: none;
+}
+
+body {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## 💡 개요

윈도우에서 scrollbar가 공간을 차지해서 페이지가 옆으로 밀려나는 문제 발견

## 📃 작업내용

- global.css에서 body의 scrollbar를 완전히 제거