### PR TITLE
🔀 로그인 전 상태에서 디테일 입장 불가능 오류 수정

### DIFF
--- a/hooks/useFetch.tsx
+++ b/hooks/useFetch.tsx
@@ -13,6 +13,7 @@ interface Props<T> {
   onFailure?: (e: unknown) => void | Promise<void>
   successMessage?: string
   errors?: ErrorsType | string
+  autoPushToggle?: boolean
 }
 
 const useFetch = <T,>({
@@ -22,6 +23,7 @@ const useFetch = <T,>({
   onFailure,
   successMessage,
   errors,
+  autoPushToggle = true,
 }: Props<T>) => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [data, setData] = useState<T | null>(null)
@@ -58,7 +60,7 @@ const useFetch = <T,>({
 
         if (onFailure) await onFailure(e)
 
-        router.push('/')
+        if (autoPushToggle) router.push('/')
       } finally {
         setIsLoading(false)
       }

--- a/hooks/useLoggedIn.tsx
+++ b/hooks/useLoggedIn.tsx
@@ -26,6 +26,7 @@ const useLoggedIn = ({ onFetch = true }: Props) => {
     onFailure: () => {
       !checkUrl && router.replace('/')
     },
+    autoPushToggle: false,
   })
 
   useEffect(() => {


### PR DESCRIPTION
## 💡 개요
로그인 전 상태에서  디테일 입장실 프로필 요청에 에러가 뜨면서 자동으로 메인페이지로 이동 하는 로직이 실행되어서 디테일 페이지에 들어갈 수 없는 상태이다

## 📃 작업내용
* 에러발생 자동 이동 로직에 toggle기능 추가


