### PR TITLE
🔀 동아리 수정 페이지 유효성 검사 수정

### DIFF
--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -23,6 +23,7 @@ const Edit = ({ initialData, banner, activity }: Props) => {
     register,
     watch,
     formState: { errors },
+    setError,
     handleSubmit,
     reset,
   } = useForm<EditClubForm>({
@@ -55,6 +56,7 @@ const Edit = ({ initialData, banner, activity }: Props) => {
   }
 
   const onSubmit = async (form: EditClubForm) => {
+    if (!form.teacher?.trim()) return setError('teacher', {})
     mutation({
       clubId,
       body: {
@@ -143,7 +145,8 @@ const Edit = ({ initialData, banner, activity }: Props) => {
       <Input
         label='담당 선생님'
         placeholder='담당 선생님 성함을 입력해주세요.'
-        register={register('teacher', { maxLength: 10, minLength: 1 })}
+        register={register('teacher')}
+        error={!!errors.teacher}
         optional
       />
     </S.Wrapper>

--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -84,14 +84,22 @@ const Edit = ({ initialData, banner, activity }: Props) => {
       <Input
         label='동아리 이름'
         placeholder='동아리 이름을 입력해주세요.'
-        register={register('name', { required: true })}
+        register={register('name', {
+          required: true,
+          minLength: 1,
+          maxLength: 25,
+        })}
         error={!!errors.name}
       />
 
       <Input
         label='동아리 연락처'
         placeholder='연락처를 입력해주세요. (디스코드, 이메일 등)'
-        register={register('contact', { required: true })}
+        register={register('contact', {
+          required: true,
+          minLength: 1,
+          maxLength: 50,
+        })}
         error={!!errors.contact}
       />
 
@@ -104,7 +112,11 @@ const Edit = ({ initialData, banner, activity }: Props) => {
           error={!!errors.bannerImg}
         />
         <Textarea
-          register={register('content', { required: true })}
+          register={register('content', {
+            required: true,
+            maxLength: 200,
+            minLength: 1,
+          })}
           content={watch('content')}
           error={!!errors.content}
         />
@@ -121,14 +133,17 @@ const Edit = ({ initialData, banner, activity }: Props) => {
       <Input
         label='노션 링크'
         placeholder='url을 입력해주세요.'
-        register={register('notionLink', { required: true })}
+        register={register('notionLink', {
+          required: true,
+          pattern: /https:\/\//,
+        })}
         error={!!errors.notionLink}
       />
 
       <Input
         label='담당 선생님'
         placeholder='담당 선생님 성함을 입력해주세요.'
-        register={register('teacher')}
+        register={register('teacher', { maxLength: 10, minLength: 1 })}
         optional
       />
     </S.Wrapper>


### PR DESCRIPTION
## 💡 개요

동아리 수정페이지에서 유효성 검사를 수정했습니다

## 📃 작업내용

- 동아리 제목 길이 제한 (1 ~ 25자)
- 동아리 연락처 길이 제한 (1 ~ 50자)
- 동아리 설명 길이 제한 (1 ~ 200자)
- 노션 링크 유효성 검사 (`/https:\/\//`)
- 담당 선생님 길이 제한 (공백 없이)