### PR TITLE
🔀 동아리 생성 유효성 검사 수정

### DIFF
--- a/components/ClubCreationModal/Page/ClubInfoInput.tsx
+++ b/components/ClubCreationModal/Page/ClubInfoInput.tsx
@@ -14,6 +14,7 @@ const ClubInfoInput = () => {
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<SetClubInfoPayload>({
     defaultValues: {
@@ -26,6 +27,8 @@ const ClubInfoInput = () => {
   const dispatch = useDispatch()
 
   const onSubmit = (form: SetClubInfoPayload) => {
+    if (!form.teacher?.trim()) return setError('teacher', {})
+
     dispatch(setClubInfo(form))
     dispatch(nextPage())
   }
@@ -36,14 +39,14 @@ const ClubInfoInput = () => {
         label='동아리 이름'
         placeholder='동아리 이름을 입력해 주세요.'
         errorPlaceholder='동아리 이름을 입력하지 않았어요.'
-        register={register('name', { required: true })}
+        register={register('name', { required: true, maxLength: 25 })}
         error={!!errors.name}
       />
 
       <Input
         label='동아리 연락처'
         placeholder='연락처를 입력해주세요.(디스코드, 이메일등)'
-        register={register('contact', { required: true })}
+        register={register('contact', { required: true, maxLength: 50 })}
         error={!!errors.contact}
       />
 
@@ -52,7 +55,7 @@ const ClubInfoInput = () => {
         placeholder='url을 입력해주세요.'
         register={register('notionLink', {
           required: true,
-          pattern: /https?:\/\//,
+          pattern: /https:\/\//,
         })}
         error={!!errors.notionLink}
       />
@@ -63,6 +66,7 @@ const ClubInfoInput = () => {
         optional
         description='담당 선생님은 전공 동아리 외에는 입력하지 않아도 돼요.'
         register={register('teacher')}
+        error={!!errors.teacher}
       />
     </Layout>
   )


### PR DESCRIPTION
## 💡 개요

동아리 생성 유효성 검사를 수정했습니다

## 📃 작업내용

- 동아리 제목 길이 제한 (1 ~ 25자)
- 동아리 연락처 길이 제한 (1 ~ 50자)
- 동아리 설명 길이 제한 (1 ~ 200자)
- 노션 링크 유효성 검사 (/https:\/\//)
- 담당 선생님 길이 제한 (공백은 허용 안하게)