### PR TITLE
🔀 통계페이지 동아리 리스트별 페이지를 구별

### DIFF
--- a/components/StatisticsPage/FileDownload/index.tsx
+++ b/components/StatisticsPage/FileDownload/index.tsx
@@ -5,13 +5,15 @@ import * as S from './style'
 import * as SVG from '@/assets/svg'
 import { useExcelDownload } from '@/hooks'
 import RequestClubType from '@/lib/requestClubType'
+import { useRouter } from 'next/router'
 
 interface Props {
   type: ClubOptionType
-  onChange: (type: ClubOptionType) => void
 }
 
-const FileDownload = ({ type, onChange }: Props) => {
+const FileDownload = ({ type }: Props) => {
+  const router = useRouter()
+
   const clubTypeKorean = RequestClubType(type || 'MAJOR')
   const { download: clubDownload } = useExcelDownload({
     method: 'get',
@@ -24,6 +26,13 @@ const FileDownload = ({ type, onChange }: Props) => {
     url: `/admin/excel/club/grade?clubType=${type || 'MAJOR'}`,
     fileName: `${clubTypeKorean}/동아리별 출력`,
   })
+
+  const onChange = (type: ClubOptionType) => {
+    router.push({
+      pathname: '/statistics',
+      query: type && { type },
+    })
+  }
 
   return (
     <S.Wrapper>

--- a/components/StatisticsPage/index.tsx
+++ b/components/StatisticsPage/index.tsx
@@ -5,9 +5,11 @@ import FileDownload from './FileDownload'
 import Statistics from './Statistics'
 import * as S from './style'
 import * as SVG from '@/assets/svg'
+import { useRouter } from 'next/router'
 
 const StatisticsPage = () => {
-  const [type, setType] = useState<ClubOptionType>('')
+  const router = useRouter()
+  const type = router.query.type?.toString() as ClubOptionType
   const [search, setSearch] = useState<string>('')
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) =>
@@ -23,7 +25,7 @@ const StatisticsPage = () => {
         <input onChange={onChange} value={search} placeholder='검색' />
       </S.InputWrapper>
 
-      <FileDownload type={type} onChange={setType} />
+      <FileDownload type={type} />
 
       <ClubList type={type} search={search} />
     </S.Wrapper>

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -3,7 +3,7 @@ import NotFoundPage from '@/components/NotFoundPage'
 import StatisticsPage from '@/components/StatisticsPage'
 import { GetServerSideProps } from 'next'
 
-export const getServerSideProps: GetServerSideProps = async (contex) => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const clubList = ['FREEDOM', 'EDITORIAL', '']
   const type = contex.query.type?.toString() || ''
   if (clubList.includes(type)) {

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -1,7 +1,25 @@
 import Header from '@/components/Header'
+import NotFoundPage from '@/components/NotFoundPage'
 import StatisticsPage from '@/components/StatisticsPage'
+import { GetServerSideProps } from 'next'
 
-const Statistics = () => {
+export const getServerSideProps: GetServerSideProps = async (contex) => {
+  const clubList = ['FREEDOM', 'EDITORIAL', '']
+  const type = contex.query.type?.toString() || ''
+  if (clubList.includes(type)) {
+    return { props: { ok: true } }
+  } else {
+    return { props: { ok: false } }
+  }
+}
+
+interface Props {
+  ok: string
+}
+
+const Statistics = ({ ok }: Props) => {
+  if (!ok) return <NotFoundPage />
+
   return (
     <>
       <Header />

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -5,7 +5,7 @@ import { GetServerSideProps } from 'next'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const clubList = ['FREEDOM', 'EDITORIAL', '']
-  const type = contex.query.type?.toString() || ''
+  const type = context.query.type?.toString() || ''
   if (clubList.includes(type)) {
     return { props: { ok: true } }
   } else {


### PR DESCRIPTION
## 💡 개요
통계페이지에서 페이지 변경 후 다시 돌아오면 동아리 타입이 기본값으로 초기화 되는 이슈

## 📃 작업내용
* 쿼리로 동아리 타입 구별 로직 구현
