### PR TITLE
🔀 동아리 수정할 때 담당 선생님 에러 처리 수정

### DIFF
--- a/components/ClubCreationModal/Page/ClubInfoInput.tsx
+++ b/components/ClubCreationModal/Page/ClubInfoInput.tsx
@@ -14,7 +14,7 @@ const ClubInfoInput = () => {
   const {
     register,
     handleSubmit,
-    setError,
+    setValue,
     formState: { errors },
   } = useForm<SetClubInfoPayload>({
     defaultValues: {
@@ -27,7 +27,7 @@ const ClubInfoInput = () => {
   const dispatch = useDispatch()
 
   const onSubmit = (form: SetClubInfoPayload) => {
-    if (!form.teacher?.trim()) return setError('teacher', {})
+    setValue('teacher', form.teacher?.trim())
 
     dispatch(setClubInfo(form))
     dispatch(nextPage())
@@ -66,7 +66,6 @@ const ClubInfoInput = () => {
         optional
         description='담당 선생님은 전공 동아리 외에는 입력하지 않아도 돼요.'
         register={register('teacher')}
-        error={!!errors.teacher}
       />
     </Layout>
   )

--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -146,7 +146,6 @@ const Edit = ({ initialData, banner, activity }: Props) => {
         label='담당 선생님'
         placeholder='담당 선생님 성함을 입력해주세요.'
         register={register('teacher')}
-        error={!!errors.teacher}
         optional
       />
     </S.Wrapper>

--- a/components/ClubEdit/components/Edit/index.tsx
+++ b/components/ClubEdit/components/Edit/index.tsx
@@ -23,7 +23,7 @@ const Edit = ({ initialData, banner, activity }: Props) => {
     register,
     watch,
     formState: { errors },
-    setError,
+    setValue,
     handleSubmit,
     reset,
   } = useForm<EditClubForm>({
@@ -56,7 +56,7 @@ const Edit = ({ initialData, banner, activity }: Props) => {
   }
 
   const onSubmit = async (form: EditClubForm) => {
-    if (!form.teacher?.trim()) return setError('teacher', {})
+    setValue('teacher', form.teacher?.trim())
     mutation({
       clubId,
       body: {


### PR DESCRIPTION
## 💡 개요
동아리 수정 시 담당 선생님이 빈칸일 때 에러 상태로 나타난다
## 🔀 변경사항
onSubmit에서 담당 선생님 value를 `trim()`후 빈칸인지 확인하는 대신 무조건 `trim()`하도록 변경했다.