### PR TITLE
🔀 토큰 재발급 로직 수정

### DIFF
--- a/lib/Observable.ts
+++ b/lib/Observable.ts
@@ -1,0 +1,32 @@
+import type { CallbackType } from '@/type/lib/Observable'
+
+class Observable {
+  private observers: Observer[] = []
+
+  setObserver(callback: CallbackType) {
+    const observer = new Observer(callback)
+    this.observers.push(observer)
+
+    return observer
+  }
+
+  notifyAll() {
+    this.observers.forEach((observer) => {
+      observer.callback()
+    })
+
+    this.observers = []
+  }
+}
+
+class Observer {
+  callback: CallbackType
+
+  constructor(callback: CallbackType) {
+    this.callback = callback
+  }
+}
+
+const observable = new Observable()
+
+export default observable

--- a/lib/Observable.ts
+++ b/lib/Observable.ts
@@ -14,7 +14,9 @@ class Observable {
     this.observers.forEach((observer) => {
       observer.callback()
     })
+  }
 
+  removeAll() {
     this.observers = []
   }
 }

--- a/lib/delay.ts
+++ b/lib/delay.ts
@@ -1,7 +1,0 @@
-const delay = async (ms: number) => {
-  return await new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
-
-export default delay

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -4,7 +4,7 @@ import TokenManager from '@/api/TokenManager'
 import axios from 'axios'
 import { TokensType } from '@/type/api/TokenManager'
 import { RootState } from '.'
-import delay from '@/lib/delay'
+import observable from '@/lib/Observable'
 
 export const reissueToken = createAsyncThunk(
   'reissue/reissueToken',
@@ -16,9 +16,9 @@ export const reissueToken = createAsyncThunk(
       reissue.isLoading ||
       tokenManager.calculateMinutes(reissue.refreshDate, 1) >= new Date()
     ) {
-      while ((getState() as RootState).reissue.isLoading) {
-        await delay(100)
-      }
+      await new Promise((resolve) => {
+        observable.setObserver(resolve)
+      })
       return
     }
 
@@ -37,6 +37,7 @@ export const reissueToken = createAsyncThunk(
         },
       }
     )
+    observable.notifyAll()
 
     tokenManager.setTokens(data)
     return data

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -38,6 +38,7 @@ export const reissueToken = createAsyncThunk(
       }
     )
     observable.notifyAll()
+    observable.removeAll()
 
     tokenManager.setTokens(data)
     return data

--- a/type/lib/Observable.ts
+++ b/type/lib/Observable.ts
@@ -1,0 +1,1 @@
+export type CallbackType = (value?: unknown) => void


### PR DESCRIPTION
## 💡 개요

기존 while문을 사용하던 문제를 observer 패턴을 사용해 해결했습니다

## 📃 작업내용

- Observable 생성
- reissue 로직에 Observable 사용
- 필요없는 delay 함수 삭제

## 🔀 변경사항

기존에는 

1. refresh 요청
2. refresh 요청을 최근에 날리지 않았고 현재 refresh 요청을 날리는 중이라면 while 문에서 무한 반복
3. isLoading 값이 false 로 돌아오면 while문을 탈출함

이런 방식이었다면 
이번에는 아래와 같은 방식으로 변경

1. refresh 요청
2. 조건은 전과 같지만 while에서 무한 반복을 하지 않고 observer라는 객체를 생성하고 resolve 함수를 넘겨줌
3. 다른 곳에서 refresh 요청이 끝나면 notifyAll 실행함
4. notifyAll에서는 갖고 있는 모든 observer의 callback 함수를 실행시킴
5. callback 안에는 resolve 가 들어있어서 refresh 요청을 다시 하지 않고 끝낼 수 있음

## 🎸 기타
이해했기를...