### PR TITLE
🔀 동아리 생성 시 동아리원 선택 이미지 오류

### DIFF
--- a/components/ClubCreationPage/Common/Member/style.ts
+++ b/components/ClubCreationPage/Common/Member/style.ts
@@ -17,6 +17,7 @@ export const UserInfo = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
+  z-index: 1;
 `
 
 export const UserImg = styled.div`
@@ -25,9 +26,11 @@ export const UserImg = styled.div`
   aspect-ratio: 1 / 1;
   border-radius: 100%;
   overflow: hidden;
+
   img {
     object-fit: cover;
     object-position: center;
+    border-radius: 100%;
   }
 `
 
@@ -47,6 +50,7 @@ export const MemberDescription = styled.p`
 
 export const CheckBox = styled.input`
   display: none;
+  z-index: 99;
 
   &:checked + label {
     border: 0.1rem solid #8be246;


### PR DESCRIPTION
## 💡 개요
클럽 생성 시 동아리원들을 선택할 때 이미지가 네모였고 동아리원 선택을 취소하는 아이콘이 이미지 뒤에 있었습니다.
## 📃 작업내용
- 이미지를 원 모양으로 만들고 취소 아이콘의 z-index를 이미지보다 우선으로 부여했습니다.
<img width="384" alt="image" src="https://github.com/GSM-MSG/GCMS-FrontEnd-V2/assets/105215297/b281e22d-5aec-46b0-8b53-0416c7406f05">

<img width="407" alt="image" src="https://github.com/GSM-MSG/GCMS-FrontEnd-V2/assets/105215297/956d5065-614d-4024-a872-5b2cc7370480">