### PR TITLE
🔀 로그인 하지 않았을 때는 재발급하지 않는 조건 추가

### DIFF
--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -1,6 +1,7 @@
 import { accessToken, refreshToken, accessExp, refreshExp } from '@/lib/token'
 import { TokensType } from '@/type/api/TokenManager'
 import Router from 'next/router'
+import { toast } from 'react-toastify'
 
 class TokenManager {
   private _accessToken: string | null = null
@@ -58,6 +59,7 @@ class TokenManager {
     localStorage.removeItem(refreshExp)
 
     Router.push('/')
+    toast.error('다시 로그인 해주세요')
   }
 
   get accessToken() {

--- a/api/TokenManager.ts
+++ b/api/TokenManager.ts
@@ -1,7 +1,5 @@
-import { accessToken, refreshToken, accessExp, refreshExp } from '@/lib/token'
+import { accessExp, accessToken, refreshExp, refreshToken } from '@/lib/token'
 import { TokensType } from '@/type/api/TokenManager'
-import Router from 'next/router'
-import { toast } from 'react-toastify'
 
 class TokenManager {
   private _accessToken: string | null = null
@@ -57,9 +55,6 @@ class TokenManager {
     localStorage.removeItem(refreshToken)
     localStorage.removeItem(accessExp)
     localStorage.removeItem(refreshExp)
-
-    Router.push('/')
-    toast.error('다시 로그인 해주세요')
   }
 
   get accessToken() {

--- a/api/index.ts
+++ b/api/index.ts
@@ -51,7 +51,11 @@ API.interceptors.response.use(
   },
   async (error) => {
     const tokenManager = new TokenManager()
-    if (window.location.pathname !== '/' && error.response.status === 401) {
+    if (
+      tokenManager.accessToken &&
+      tokenManager.refreshToken &&
+      error.response.status === 401
+    ) {
       try {
         await store.dispatch(reissueToken())
         tokenManager.initToken()

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -9,6 +9,7 @@ import axios from 'axios'
 import { toast } from 'react-toastify'
 import { RootState } from '.'
 import { removeUser } from './user'
+import Router from 'next/router'
 
 export const reissueToken = createAsyncThunk(
   'reissue/reissueToken',
@@ -51,6 +52,7 @@ export const reissueToken = createAsyncThunk(
     } catch (e) {
       dispatch(removeUser())
       tokenManager.removeTokens()
+      Router.push('/')
       toast.error('다시 로그인 해주세요', toastOption)
       return useLoggedIn({})
     }

--- a/store/reissue.ts
+++ b/store/reissue.ts
@@ -6,7 +6,6 @@ import { TokensType } from '@/type/api/TokenManager'
 import { InitialState } from '@/type/store/reissue'
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import axios from 'axios'
-import Router from 'next/router'
 import { toast } from 'react-toastify'
 import { RootState } from '.'
 import { removeUser } from './user'
@@ -53,7 +52,6 @@ export const reissueToken = createAsyncThunk(
       dispatch(removeUser())
       tokenManager.removeTokens()
       toast.error('다시 로그인 해주세요', toastOption)
-      console.log(Router.route)
       return useLoggedIn({})
     }
   }


### PR DESCRIPTION
## 💡 개요
로그인하지 않고 동아리 상세에 들어가면 재발급 토큰이 없는데도 재발급을 시도해 계속 401이 반환된 후 홈으로 이동됩니다.
## 📃 작업내용
- 401이 뜬다는 조건과 accessToken 및 refreshToken을 가지고 있다면이라는 조건으로 수정
