### PR TITLE
🔀 클럽 생성 시 배너 이미지 권장 사이즈 설명 추가

### DIFF
--- a/components/Common/BannerImg/index.tsx
+++ b/components/Common/BannerImg/index.tsx
@@ -1,7 +1,7 @@
 import * as SVG from '@/assets/svg'
 import { UseFormRegisterReturn } from 'react-hook-form'
-import * as S from './style'
 import NoCopyBox from '../NoCopyBox'
+import * as S from './style'
 
 interface Props {
   register: UseFormRegisterReturn
@@ -23,7 +23,8 @@ const BannerImg = ({ register, error, bannerImg }: Props) => {
         <S.BannerInput error={error} htmlFor='bannerImg'>
           <SVG.Pictures error={error} />
           <S.BannerDescription error={error}>
-            배너 사진 업로드
+            <span>배너 사진 업로드</span>
+            <span>권장 최소 사이즈: 1440*1080</span>
           </S.BannerDescription>
         </S.BannerInput>
       )}

--- a/components/Common/BannerImg/style.ts
+++ b/components/Common/BannerImg/style.ts
@@ -35,5 +35,18 @@ export const Img = styled.img`
 `
 
 export const BannerDescription = styled.div<ErrorProps>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   color: ${({ error }) => (error ? '#FF6666' : '#696969')};
+
+  span {
+    &:first-of-type {
+      font-size: 12px;
+    }
+
+    &:last-of-type {
+      font-size: 10px;
+    }
+  }
 `

--- a/components/DetailPage/SideBar.tsx
+++ b/components/DetailPage/SideBar.tsx
@@ -21,11 +21,13 @@ export default function SideBar() {
       <S.SideControl>
         <S.NotionInfo>
           <p>{clubDetail.name}이/가 더 궁금하다면?</p>
-          <Link href={`${clubDetail.notionLink}`}>
-            노션 보러가기
-            <i>
-              <SVG.ShortcutsIcon />
-            </i>
+          <Link href={`${clubDetail.notionLink}`} passHref legacyBehavior>
+            <a target='_blank' rel='noopener noreferrer'>
+              노션 보러가기
+              <i>
+                <SVG.ShortcutsIcon />
+              </i>
+            </a>
           </Link>
         </S.NotionInfo>
       </S.SideControl>


### PR DESCRIPTION
## 💡 개요
배너 사이즈를 업로드할 때 권장 사이즈를 적지 않았습니다.
## 📃 작업내용
- 권장사항 설명 추가
<img width="795" alt="image" src="https://github.com/GSM-MSG/GCMS-FrontEnd-V2/assets/105215297/c4844998-d982-4c78-98e4-3b4c89b19b44">
